### PR TITLE
Add AI routing with Ollama and OpenAI clients

### DIFF
--- a/app/gpt_client.py
+++ b/app/gpt_client.py
@@ -1,0 +1,28 @@
+import os
+import logging
+from openai import AsyncOpenAI
+
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+OPENAI_MODEL = os.getenv("OPENAI_MODEL", "gpt-4o")
+
+logger = logging.getLogger(__name__)
+_client: AsyncOpenAI | None = None
+
+def get_client() -> AsyncOpenAI:
+    global _client
+    if _client is None:
+        _client = AsyncOpenAI(api_key=OPENAI_API_KEY)
+    return _client
+
+async def ask_gpt(prompt: str, model: str | None = None) -> str:
+    model = model or OPENAI_MODEL
+    client = get_client()
+    try:
+        resp = await client.chat.completions.create(
+            model=model,
+            messages=[{"role": "user", "content": prompt}],
+        )
+        return resp.choices[0].message.content.strip()
+    except Exception as e:
+        logger.exception("OpenAI request failed: %s", e)
+        raise

--- a/app/llama_client.py
+++ b/app/llama_client.py
@@ -1,0 +1,24 @@
+import os
+import httpx
+import logging
+
+OLLAMA_URL = os.getenv("OLLAMA_URL", "http://localhost:11434")
+OLLAMA_MODEL = os.getenv("OLLAMA_MODEL", "llama3")
+
+logger = logging.getLogger(__name__)
+
+async def ask_llama(prompt: str, model: str | None = None, timeout: float = 30.0) -> str:
+    """Send prompt to Ollama server and return the response text."""
+    model = model or OLLAMA_MODEL
+    try:
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            resp = await client.post(
+                f"{OLLAMA_URL}/api/generate",
+                json={"model": model, "prompt": prompt, "stream": False},
+            )
+            resp.raise_for_status()
+            data = resp.json()
+            return data.get("response", "").strip()
+    except Exception as e:
+        logger.exception("Ollama request failed: %s", e)
+        raise

--- a/app/main.py
+++ b/app/main.py
@@ -3,6 +3,7 @@ from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
 from dotenv import load_dotenv
 import os
+from .router import route_prompt
 
 load_dotenv()
 
@@ -17,8 +18,12 @@ class AskRequest(BaseModel):
 @app.post("/ask")
 async def ask(req: AskRequest):
     logger.info("Received prompt: %s", req.prompt)
-    # Placeholder response logic
-    return {"response": f"You asked: {req.prompt}"}
+    try:
+        answer = await route_prompt(req.prompt)
+        return {"response": answer}
+    except Exception as e:
+        logger.exception("Error processing prompt: %s", e)
+        raise HTTPException(status_code=500, detail="Error processing prompt")
 
 @app.get("/health")
 async def health():

--- a/app/router.py
+++ b/app/router.py
@@ -1,0 +1,30 @@
+import logging
+from .llama_client import ask_llama
+from .gpt_client import ask_gpt
+
+logger = logging.getLogger(__name__)
+
+COMPLEX_KEYWORDS = {"code", "research", "analyze", "explain"}
+
+
+def _should_use_gpt(prompt: str) -> bool:
+    words = prompt.lower().split()
+    if len(words) > 30:
+        return True
+    return any(k in words for k in COMPLEX_KEYWORDS)
+
+
+async def route_prompt(prompt: str) -> str:
+    """Decide which backend to use and return the response."""
+    if _should_use_gpt(prompt):
+        try:
+            return await ask_gpt(prompt)
+        except Exception:
+            logger.exception("GPT failed, falling back to LLaMA")
+            return await ask_llama(prompt)
+    else:
+        try:
+            return await ask_llama(prompt)
+        except Exception:
+            logger.exception("LLaMA failed, falling back to GPT")
+            return await ask_gpt(prompt)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ fastapi
 uvicorn
 python-dotenv
 openai
+httpx
 homeassistant


### PR DESCRIPTION
## Summary
- add an Ollama client for llama3 calls
- add an OpenAI client
- create a simple router with fallback logic
- use the router in the `/ask` endpoint
- include httpx in requirements

## Testing
- `python -m compileall -q app`
- `python - <<'PY'
import asyncio
from app.router import route_prompt
async def test():
    try:
        await route_prompt("hello")
    except Exception as e:
        print("final", type(e).__name__)
asyncio.run(test())
PY`

------
https://chatgpt.com/codex/tasks/task_e_687e9b57db90832aab91db777e5d6e61