### PR TITLE
Add Home Assistant API client and integrate entity resolution

### DIFF
--- a/app/home_assistant.py
+++ b/app/home_assistant.py
@@ -1,0 +1,97 @@
+import os
+import logging
+import httpx
+import re
+from typing import Any, Optional
+
+HOME_ASSISTANT_URL = os.getenv("HOME_ASSISTANT_URL")
+HOME_ASSISTANT_TOKEN = os.getenv("HOME_ASSISTANT_TOKEN")
+
+logger = logging.getLogger(__name__)
+
+HEADERS = {
+    "Authorization": f"Bearer {HOME_ASSISTANT_TOKEN}",
+    "Content-Type": "application/json",
+}
+
+
+async def _request(
+    method: str, path: str, json: dict | None = None, timeout: float = 10.0
+) -> Any:
+    """Internal helper to talk to the Home Assistant API."""
+    if not HOME_ASSISTANT_URL or not HOME_ASSISTANT_TOKEN:
+        raise RuntimeError("Home Assistant credentials not configured")
+    url = f"{HOME_ASSISTANT_URL.rstrip('/')}/api{path}"
+    async with httpx.AsyncClient(timeout=timeout) as client:
+        resp = await client.request(method, url, headers=HEADERS, json=json)
+        resp.raise_for_status()
+        if resp.content:
+            return resp.json()
+        return None
+
+
+async def get_states() -> list[dict]:
+    """Return all entity states."""
+    data = await _request("GET", "/states")
+    return data if isinstance(data, list) else []
+
+
+async def call_service(domain: str, service: str, data: dict) -> Any:
+    """Call a Home Assistant service."""
+    return await _request("POST", f"/services/{domain}/{service}", json=data)
+
+
+async def turn_on(entity_id: str) -> Any:
+    domain = entity_id.split(".")[0]
+    return await call_service(domain, "turn_on", {"entity_id": entity_id})
+
+
+async def turn_off(entity_id: str) -> Any:
+    domain = entity_id.split(".")[0]
+    return await call_service(domain, "turn_off", {"entity_id": entity_id})
+
+
+# ---------------------------------------------------------------------------
+# Dynamic entity resolution (line 78)
+# ---------------------------------------------------------------------------
+async def resolve_entity(name: str) -> Optional[str]:
+    """Match a user-provided name to an actual Home Assistant entity ID."""
+    states = await get_states()
+    name_lower = name.lower()
+    # exact id or friendly name
+    for st in states:
+        if st.get("entity_id", "").lower() == name_lower:
+            return st["entity_id"]
+        friendly = st.get("attributes", {}).get("friendly_name", "")
+        if friendly and friendly.lower() == name_lower:
+            return st["entity_id"]
+    # partial match as fallback
+    for st in states:
+        if name_lower in st.get("entity_id", "").lower():
+            return st["entity_id"]
+        friendly = st.get("attributes", {}).get("friendly_name", "").lower()
+        if name_lower in friendly:
+            return st["entity_id"]
+    return None
+
+
+async def handle_command(prompt: str) -> Optional[str]:
+    """Simple intent parser to toggle entities."""
+    m = re.match(
+        r"^(?:ha[:]?)?\s*(?:turn|switch)\s+(on|off)\s+(.+)$", prompt.strip(), re.I
+    )
+    if not m:
+        return None
+    action, name = m.group(1).lower(), m.group(2).strip()
+    entity_id = await resolve_entity(name)
+    if not entity_id:
+        return f"Entity '{name}' not found"
+    try:
+        if action == "on":
+            await turn_on(entity_id)
+            return f"Turned on {entity_id}"
+        await turn_off(entity_id)
+        return f"Turned off {entity_id}"
+    except Exception as e:
+        logger.exception("Failed to control %s: %s", entity_id, e)
+        return "Failed to execute command"

--- a/app/main.py
+++ b/app/main.py
@@ -4,6 +4,7 @@ from pydantic import BaseModel
 from dotenv import load_dotenv
 import os
 from .router import route_prompt
+from .home_assistant import get_states, call_service, resolve_entity
 
 load_dotenv()
 
@@ -12,8 +13,16 @@ logger = logging.getLogger(__name__)
 
 app = FastAPI(title="GesahniV2")
 
+
 class AskRequest(BaseModel):
     prompt: str
+
+
+class ServiceRequest(BaseModel):
+    domain: str
+    service: str
+    data: dict | None = None
+
 
 @app.post("/ask")
 async def ask(req: AskRequest):
@@ -25,9 +34,11 @@ async def ask(req: AskRequest):
         logger.exception("Error processing prompt: %s", e)
         raise HTTPException(status_code=500, detail="Error processing prompt")
 
+
 @app.get("/health")
 async def health():
     return {"status": "ok"}
+
 
 @app.get("/config")
 async def config():
@@ -35,12 +46,48 @@ async def config():
     config_vars = {k: v for k, v in os.environ.items() if k.isupper()}
     return config_vars
 
+
 @app.post("/intent-test")
 async def intent_test(req: AskRequest):
     logger.info("Intent test for: %s", req.prompt)
     # Placeholder: simply echo the prompt
     return {"intent": "test", "prompt": req.prompt}
 
+
+@app.get("/ha/entities")
+async def ha_entities():
+    try:
+        return await get_states()
+    except Exception as e:
+        logger.exception("HA states error: %s", e)
+        raise HTTPException(status_code=500, detail="Home Assistant error")
+
+
+@app.post("/ha/service")
+async def ha_service(req: ServiceRequest):
+    try:
+        resp = await call_service(req.domain, req.service, req.data or {})
+        return resp or {"status": "ok"}
+    except Exception as e:
+        logger.exception("HA service error: %s", e)
+        raise HTTPException(status_code=500, detail="Home Assistant error")
+
+
+@app.get("/ha/resolve")
+async def ha_resolve(name: str):
+    try:
+        entity = await resolve_entity(name)
+        if entity:
+            return {"entity_id": entity}
+        raise HTTPException(status_code=404, detail="Entity not found")
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.exception("HA resolve error: %s", e)
+        raise HTTPException(status_code=500, detail="Home Assistant error")
+
+
 if __name__ == "__main__":
     import uvicorn
+
     uvicorn.run(app, host="0.0.0.0", port=int(os.getenv("PORT", 8000)))

--- a/app/router.py
+++ b/app/router.py
@@ -1,6 +1,7 @@
 import logging
 from .llama_client import ask_llama
 from .gpt_client import ask_gpt
+from .home_assistant import handle_command
 
 logger = logging.getLogger(__name__)
 
@@ -16,6 +17,10 @@ def _should_use_gpt(prompt: str) -> bool:
 
 async def route_prompt(prompt: str) -> str:
     """Decide which backend to use and return the response."""
+    ha_resp = await handle_command(prompt)
+    if ha_resp is not None:
+        return ha_resp
+
     if _should_use_gpt(prompt):
         try:
             return await ask_gpt(prompt)


### PR DESCRIPTION
## Summary
- create `home_assistant.py` for interacting with Home Assistant
- implement dynamic entity resolution and simple command handling
- expose Home Assistant API actions via new `/ha/*` endpoints
- route `/ask` prompts to Home Assistant when they match toggle commands

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ea97f17c0832ab4d4686582e42317