### PR TITLE
Add recording CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,14 @@ docker build -t smart-assistant .
 docker run -d -p 8000:8000 --env-file .env smart-assistant
 ```
 
+### 🎥 Record a Session
+
+Record interaction sessions for later review:
+
+```bash
+python record_session.py --duration 5 --output ./sessions
+```
+
 ## 🎯 Endpoints
 
 * `/ask`: Send your prompt here.

--- a/record_session.py
+++ b/record_session.py
@@ -1,0 +1,24 @@
+import argparse
+import asyncio
+from pathlib import Path
+
+from app.capture import record
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Record a session")
+    parser.add_argument("--duration", type=int, required=True)
+    parser.add_argument("--output", type=str, required=True)
+    args = parser.parse_args()
+
+    out_dir = Path(args.output)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    result = record(args.duration, str(out_dir))
+    if asyncio.iscoroutine(result):
+        result = asyncio.run(result)
+    print(result)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_record_session.py
+++ b/tests/test_record_session.py
@@ -1,0 +1,39 @@
+import os
+import sys
+import subprocess
+from pathlib import Path
+
+
+def test_record_session_cli(tmp_path):
+    repo_root = Path(__file__).resolve().parents[1]
+    capture_file = repo_root / "app" / "capture.py"
+
+    stub = (
+        "def record(duration, output_dir):\n"
+        "    from pathlib import Path\n"
+        "    p = Path(output_dir) / 'saved.txt'\n"
+        "    p.write_text('data')\n"
+        "    return str(p)\n"
+    )
+
+    original = capture_file.read_text() if capture_file.exists() else None
+    capture_file.write_text(stub)
+
+    script = repo_root / "record_session.py"
+    out_dir = tmp_path / "sessions"
+    result = subprocess.run(
+        [sys.executable, str(script), "--duration", "5", "--output", str(out_dir)],
+        capture_output=True,
+        text=True,
+        cwd=repo_root,
+    )
+
+    if original is None:
+        capture_file.unlink()
+    else:
+        capture_file.write_text(original)
+
+    assert result.returncode == 0
+    saved_path = out_dir / "saved.txt"
+    assert saved_path.exists()
+    assert str(saved_path) in result.stdout


### PR DESCRIPTION
## Summary
- add `record_session.py` CLI for saving sessions
- document session recording in the README
- test CLI invocation via `subprocess.run`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68826890be1c832a8c64844f59c4ea5a