### PR TITLE
Add transcription endpoints and tests

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,7 +1,8 @@
 from dotenv import load_dotenv; load_dotenv()   #  ←  NEW TOP LINE
 
 import logging
-from fastapi import FastAPI, HTTPException
+from pathlib import Path
+from fastapi import FastAPI, HTTPException, BackgroundTasks
 from pydantic import BaseModel
 import os
 
@@ -13,10 +14,12 @@ from .llama_integration import startup_check as llama_startup
 from .middleware import RequestIDMiddleware
 from .logging_config import configure_logging
 from .status import router as status_router
+from .transcription import transcribe_file
 
 load_dotenv()
 configure_logging()
 logger = logging.getLogger(__name__)
+SESSIONS_DIR = Path(os.getenv("SESSIONS_DIR", os.path.join(os.path.dirname(__file__), "..", "sessions")))
 
 app = FastAPI(title="GesahniV2")
 app.add_middleware(RequestIDMiddleware)
@@ -90,6 +93,31 @@ async def ha_resolve(name: str):
     except Exception as e:
         logger.exception("HA resolve error: %s", e)
         raise HTTPException(status_code=500, detail="Home Assistant error")
+
+
+async def _background_transcribe(session_id: str) -> None:
+    audio_path = SESSIONS_DIR / session_id / "audio.wav"
+    transcript_path = SESSIONS_DIR / session_id / "transcript.txt"
+    try:
+        text = await transcribe_file(str(audio_path))
+        transcript_path.parent.mkdir(parents=True, exist_ok=True)
+        transcript_path.write_text(text, encoding="utf-8")
+    except Exception as e:
+        logger.exception("Transcription failed: %s", e)
+
+
+@app.post("/transcribe/{session_id}")
+async def start_transcription(session_id: str, background_tasks: BackgroundTasks):
+    background_tasks.add_task(_background_transcribe, session_id)
+    return {"status": "accepted"}
+
+
+@app.get("/transcribe/{session_id}")
+async def get_transcription(session_id: str):
+    transcript_path = SESSIONS_DIR / session_id / "transcript.txt"
+    if transcript_path.exists():
+        return {"text": transcript_path.read_text(encoding="utf-8")}
+    raise HTTPException(status_code=404, detail="Transcript not found")
 
 
 if __name__ == "__main__":

--- a/app/transcription.py
+++ b/app/transcription.py
@@ -1,0 +1,21 @@
+import os
+from openai import AsyncOpenAI
+
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+TRANSCRIBE_MODEL = os.getenv("OPENAI_TRANSCRIBE_MODEL", "whisper-1")
+
+_client: AsyncOpenAI | None = None
+
+def _get_client() -> AsyncOpenAI:
+    global _client
+    if _client is None:
+        _client = AsyncOpenAI(api_key=OPENAI_API_KEY)
+    return _client
+
+async def transcribe_file(path: str, model: str | None = None) -> str:
+    """Send the audio file to OpenAI whisper API and return the transcript."""
+    model = model or TRANSCRIBE_MODEL
+    client = _get_client()
+    with open(path, "rb") as f:
+        resp = await client.audio.transcriptions.create(model=model, file=f)
+    return resp.text

--- a/tests/test_transcribe.py
+++ b/tests/test_transcribe.py
@@ -1,0 +1,42 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from fastapi.testclient import TestClient
+
+
+def setup_app(monkeypatch, tmp_path):
+    os.environ["OLLAMA_URL"] = "http://x"
+    os.environ["OLLAMA_MODEL"] = "llama3"
+    os.environ["HOME_ASSISTANT_URL"] = "http://ha"
+    os.environ["HOME_ASSISTANT_TOKEN"] = "token"
+    from app import main
+    monkeypatch.setattr(main, "ha_startup", lambda: None)
+    monkeypatch.setattr(main, "llama_startup", lambda: None)
+    monkeypatch.setattr(main, "SESSIONS_DIR", tmp_path)
+    return main
+
+
+def test_transcribe_post_and_file_created(monkeypatch, tmp_path):
+    main = setup_app(monkeypatch, tmp_path)
+
+    async def fake_transcribe(path):
+        return "hello"
+
+    monkeypatch.setattr(main, "transcribe_file", fake_transcribe)
+    client = TestClient(main.app)
+    resp = client.post("/transcribe/123")
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "accepted"}
+    transcript = tmp_path / "123" / "transcript.txt"
+    assert transcript.read_text() == "hello"
+
+
+def test_transcribe_get(monkeypatch, tmp_path):
+    main = setup_app(monkeypatch, tmp_path)
+    session = tmp_path / "abc"
+    session.mkdir()
+    (session / "transcript.txt").write_text("hi")
+    client = TestClient(main.app)
+    resp = client.get("/transcribe/abc")
+    assert resp.status_code == 200
+    assert resp.json() == {"text": "hi"}


### PR DESCRIPTION
## Summary
- implement `/transcribe/{session_id}` POST/GET routes
- background task runs `transcribe_file` and saves to `sessions/<id>/transcript.txt`
- create `transcription` module using OpenAI Whisper
- test transcription endpoints

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882689a607c832a86d7945316454768