### PR TITLE
Add file upload endpoint

### DIFF
--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -1,0 +1,25 @@
+import sys, os
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from fastapi.testclient import TestClient
+
+
+def test_upload_saves_file(tmp_path, monkeypatch):
+    os.environ["OLLAMA_URL"] = "http://x"
+    os.environ["OLLAMA_MODEL"] = "llama3"
+    os.environ["HOME_ASSISTANT_URL"] = "http://ha"
+    os.environ["HOME_ASSISTANT_TOKEN"] = "token"
+    from app import main
+
+    monkeypatch.setattr(main, "ha_startup", lambda: None)
+    monkeypatch.setattr(main, "llama_startup", lambda: None)
+    monkeypatch.setattr(main, "SESSIONS_DIR", str(tmp_path))
+
+    client = TestClient(main.app)
+    data = b"abc"
+    resp = client.post("/upload", files={"file": ("foo.wav", data, "audio/wav")})
+    assert resp.status_code == 200
+    sid = resp.json()["session_id"]
+    saved = tmp_path / sid / "source.wav"
+    assert saved.exists()
+    assert saved.read_bytes() == data
+


### PR DESCRIPTION
## Summary
- add upload endpoint in app/main.py
- store uploaded file in `sessions/<session_id>/source.wav`
- test uploading a file with TestClient

## Testing
- `pip install -q -r requirements.txt`
- `pip install -q python-multipart`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68826898dda0832a9e33ef7c4229cbb9