### PR TITLE
Add Docker Compose for local dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,16 @@ docker build -t smart-assistant .
 docker run -d -p 8000:8000 --env-file .env smart-assistant
 ```
 
+### 🐳 Docker Compose
+
+For local development you can spin everything up with Docker Compose. The
+service reads variables from your `.env` file and stores chat sessions under
+`./sessions`:
+
+```bash
+docker compose up
+```
+
 ## 🎯 Endpoints
 
 * `/ask`: Send your prompt here.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+version: '3.8'
+services:
+  app:
+    image: python:3.11-slim
+    working_dir: /code
+    command: sh -c "pip install --no-cache-dir -r requirements.txt && uvicorn app.main:app --host 0.0.0.0 --port 8000"
+    volumes:
+      - ./app:/code/app
+      - ./requirements.txt:/code/requirements.txt
+      - ./sessions:/code/sessions
+    env_file:
+      - .env
+    environment:
+      - OLLAMA_URL=${OLLAMA_URL}
+      - OLLAMA_MODEL=${OLLAMA_MODEL}
+      - OPENAI_API_KEY=${OPENAI_API_KEY}
+      - OPENAI_MODEL=${OPENAI_MODEL}
+      - HOME_ASSISTANT_URL=${HOME_ASSISTANT_URL}
+      - HOME_ASSISTANT_TOKEN=${HOME_ASSISTANT_TOKEN}
+      - LOG_LEVEL=${LOG_LEVEL}
+    ports:
+      - "8000:8000"


### PR DESCRIPTION
## Summary
- add docker-compose.yml with FastAPI service
- persist sessions directory and use environment variables
- document compose usage in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6882689c2960832a91b0d21698e66435