### PR TITLE
Enhance telemetry logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,24 @@ curl -X POST localhost:8000/ask -d '{"prompt":"turn off kitchen lights"}'
 * Check logs at `/config` endpoint.
 * Detailed error logs saved locally.
 
+## Event Log
+
+Each `/ask` request writes a JSON object to `data/history.jsonl` capturing core
+metadata and timing. New fields include `session_id`, `latency_ms`, `status` and
+token usage. Missing fields default to `null`.
+
+```json
+{
+  "req_id": "abc123",
+  "session_id": "s-42",
+  "prompt": "turn on hallway light",
+  "engine_used": "LightsSkill",
+  "response": "Done.",
+  "latency_ms": 120,
+  "status": "OK"
+}
+```
+
 ---
 
 Made by the King, for the King. Let's run it! 🚀🔥

--- a/app/gpt_client.py
+++ b/app/gpt_client.py
@@ -14,7 +14,8 @@ def get_client() -> AsyncOpenAI:
         _client = AsyncOpenAI(api_key=OPENAI_API_KEY)
     return _client
 
-async def ask_gpt(prompt: str, model: str | None = None) -> str:
+async def ask_gpt(prompt: str, model: str | None = None) -> tuple[str, int, int, float]:
+    """Return text, prompt tokens, completion tokens and price per 1k tokens."""
     model = model or OPENAI_MODEL
     client = get_client()
     try:
@@ -22,7 +23,13 @@ async def ask_gpt(prompt: str, model: str | None = None) -> str:
             model=model,
             messages=[{"role": "user", "content": prompt}],
         )
-        return resp.choices[0].message.content.strip()
+        text = resp.choices[0].message.content.strip()
+        usage = resp.usage or {}
+        pt = int(getattr(usage, "prompt_tokens", 0))
+        ct = int(getattr(usage, "completion_tokens", 0))
+        unit_price = 0.0
+        return text, pt, ct, unit_price
     except Exception as e:
         logger.exception("OpenAI request failed: %s", e)
         raise
+

--- a/app/home_assistant.py
+++ b/app/home_assistant.py
@@ -4,6 +4,8 @@ import httpx
 import re
 from typing import Any, List, Optional
 
+from .telemetry import log_record_var
+
 HOME_ASSISTANT_URL = os.getenv("HOME_ASSISTANT_URL")
 HOME_ASSISTANT_TOKEN = os.getenv("HOME_ASSISTANT_TOKEN")
 
@@ -43,7 +45,13 @@ async def get_states() -> list[dict]:
 
 
 async def call_service(domain: str, service: str, data: dict) -> Any:
-    """Call a Home Assistant service."""
+    """Call a Home Assistant service and record telemetry."""
+    rec = log_record_var.get()
+    if rec is not None:
+        rec.ha_service_called = f"{domain}.{service}"
+        ids = data.get("entity_id")
+        if ids is not None:
+            rec.entity_ids = [ids] if isinstance(ids, str) else list(ids)
     return await _request("POST", f"/services/{domain}/{service}", json=data)
 
 

--- a/app/telemetry.py
+++ b/app/telemetry.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import List, Optional, Any
+from contextvars import ContextVar
+
+from pydantic import BaseModel
+
+
+def utc_now() -> datetime:
+    """Return current UTC time."""
+    return datetime.now(timezone.utc)
+
+
+class LogRecord(BaseModel):
+    # existing keys
+    req_id: str
+    prompt: Optional[str] = None
+    engine_used: Optional[str] = None
+    response: Optional[str] = None
+    timestamp: Optional[str] = None
+
+    # core request metadata
+    session_id: Optional[str] = None
+    user_id: Optional[str] = None
+    channel: Optional[str] = None
+
+    # timing & status
+    received_at: Optional[str] = None
+    started_at: Optional[str] = None
+    finished_at: Optional[str] = None
+    latency_ms: Optional[int] = None
+    status: Optional[str] = None
+
+    # routing / skills
+    matched_skill: Optional[str] = None
+    match_confidence: Optional[float] = None
+
+    # llm usage
+    model_name: Optional[str] = None
+    prompt_tokens: Optional[int] = None
+    completion_tokens: Optional[int] = None
+    cost_usd: Optional[float] = None
+
+    # home assistant audit
+    ha_service_called: Optional[str] = None
+    entity_ids: Optional[List[str]] = None
+    state_before: Optional[Any] = None
+    state_after: Optional[Any] = None
+
+    # vector/RAG debugging
+    rag_top_k: Optional[int] = None
+    rag_doc_ids: Optional[List[str]] = None
+    rag_scores: Optional[List[float]] = None
+
+
+log_record_var: ContextVar[LogRecord | None] = ContextVar("log_record", default=None)

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -6,13 +6,15 @@ import pytest
 import asyncio
 from app.history import append_history, HISTORY_FILE
 from app.logging_config import req_id_var
+from app.telemetry import LogRecord
 
 
 def test_history_appends_entry(tmp_path, monkeypatch):
     hist = tmp_path / "history.json"
     monkeypatch.setattr("app.history.HISTORY_FILE", str(hist))
     token = req_id_var.set("testid")
-    asyncio.run(append_history("prompt", "llama", "resp"))
+    rec = LogRecord(req_id="testid", prompt="prompt", engine_used="llama", response="resp")
+    asyncio.run(append_history(rec))
     req_id_var.reset(token)
     with open(hist) as f:
         data = json.load(f)

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -12,7 +12,7 @@ def test_router_fallback_metrics_updated(monkeypatch):
         return {"error": "timeout", "llm_used": "llama3"}
 
     async def fake_gpt(prompt):
-        return "ok"
+        return "ok", 0, 0, 0.0
 
     monkeypatch.setattr(router, "detect_intent", lambda p: ("chat", "high"))
     monkeypatch.setattr(router, "ask_llama", fake_llama)

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -1,0 +1,29 @@
+import os, sys, json
+from fastapi.testclient import TestClient
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+
+def setup_app(monkeypatch, hist_path):
+    os.environ["OLLAMA_URL"] = "http://x"
+    os.environ["OLLAMA_MODEL"] = "llama3"
+    os.environ["HOME_ASSISTANT_URL"] = "http://ha"
+    os.environ["HOME_ASSISTANT_TOKEN"] = "token"
+    from app import main
+    monkeypatch.setattr(main, "ha_startup", lambda: None)
+    monkeypatch.setattr(main, "llama_startup", lambda: None)
+    monkeypatch.setattr("app.history.HISTORY_FILE", hist_path)
+    async def fake_route(prompt: str):
+        return "ok"
+    monkeypatch.setattr(main, "route_prompt", fake_route)
+    return TestClient(main.app)
+
+
+def test_telemetry_logged(monkeypatch, tmp_path):
+    hist = tmp_path / "hist.jsonl"
+    client = setup_app(monkeypatch, str(hist))
+    resp = client.post("/ask", json={"prompt": "hi"})
+    assert resp.status_code == 200
+    line = hist.read_text().splitlines()[-1]
+    data = json.loads(line)
+    assert data["status"] == "OK"
+    assert data["latency_ms"] > 0


### PR DESCRIPTION
## Summary
- add new `LogRecord` model with rich telemetry fields
- track and persist request metadata via new middleware
- capture HA service calls and LLM token usage
- update history writer to accept `LogRecord`
- document event log schema
- add tests for telemetry

## Testing
- `ruff check app/telemetry.py app/history.py app/main.py app/home_assistant.py app/skills/base.py app/router.py app/gpt_client.py tests/test_router.py tests/test_history.py tests/test_telemetry.py >/tmp/ruff.log && tail -n 20 /tmp/ruff.log`
- `mypy app >/tmp/mypy.log && tail -n 20 /tmp/mypy.log`
- `pytest -q >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`

------
https://chatgpt.com/codex/tasks/task_e_68877ee7d23c832a8cfea238566d5f56