### PR TITLE
Add simple React chat UI

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import React, { useState } from 'react';
+import Chat, { Message } from '../components/Chat';
+import InputBar from '../components/InputBar';
+import { sendPrompt } from '../lib/api';
+
+export default function Page() {
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  const handleSend = async (text: string) => {
+    const userMessage: Message = { role: 'user', content: text };
+    setMessages(msgs => [...msgs, userMessage]);
+    setLoading(true);
+    try {
+      const reply = await sendPrompt(text);
+      const aiMessage: Message = { role: 'assistant', content: reply };
+      setMessages(msgs => [...msgs, aiMessage]);
+    } catch (err: any) {
+      setMessages(msgs => [...msgs, { role: 'assistant', content: `Error: ${err.message}` }]);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <main className="max-w-2xl mx-auto p-4">
+      <Chat messages={messages} />
+      <InputBar onSend={handleSend} disabled={loading} />
+    </main>
+  );
+}

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+
+export interface Message {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+interface ChatProps {
+  messages: Message[];
+}
+
+const Chat: React.FC<ChatProps> = ({ messages }) => {
+  return (
+    <div className="space-y-2">
+      {messages.map((m, i) => (
+        <div key={i} className={m.role === 'user' ? 'text-right' : 'text-left'}>
+          <span className={
+            m.role === 'user'
+              ? 'bg-blue-500 text-white rounded px-2 py-1'
+              : 'bg-gray-200 rounded px-2 py-1'
+          }>
+            {m.content}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default Chat;

--- a/src/components/InputBar.tsx
+++ b/src/components/InputBar.tsx
@@ -1,0 +1,44 @@
+import React, { useState } from 'react';
+
+interface InputBarProps {
+  onSend: (text: string) => void;
+  disabled?: boolean;
+}
+
+const InputBar: React.FC<InputBarProps> = ({ onSend, disabled }) => {
+  const [value, setValue] = useState('');
+
+  const send = () => {
+    const text = value.trim();
+    if (!text) return;
+    onSend(text);
+    setValue('');
+  };
+
+  const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      send();
+    }
+  };
+
+  return (
+    <div className="flex space-x-2 mt-4">
+      <input
+        className="flex-grow border rounded px-2 py-1"
+        value={value}
+        onChange={e => setValue(e.target.value)}
+        onKeyDown={onKeyDown}
+        disabled={disabled}
+      />
+      <button
+        className="px-4 py-1 bg-blue-600 text-white rounded"
+        onClick={send}
+        disabled={disabled}
+      >
+        Send
+      </button>
+    </div>
+  );
+};
+
+export default InputBar;

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,0 +1,16 @@
+const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
+
+export async function sendPrompt(prompt: string): Promise<string> {
+  const res = await fetch(`${API_URL}/ask`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ prompt })
+  });
+
+  if (!res.ok) {
+    throw new Error(`Request failed: ${res.status}`);
+  }
+
+  const data: { response: string } = await res.json();
+  return data.response;
+}


### PR DESCRIPTION
## Summary
- add `sendPrompt` helper for calling backend
- implement `Chat` and `InputBar` components
- wire together a basic chat page using these components

## Testing
- `pip install -r requirements.txt`
- `pip install aiofiles numpy python-multipart scipy`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688790acebe4832a94142fc76bc77b8e