### PR TITLE
Introduce keyword catalog router

### DIFF
--- a/app/keyword_catalog.py
+++ b/app/keyword_catalog.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Optional, Type, Dict, List
+
+from .skills import MathSkill, TranslateSkill, SearchSkill, TimerSkill, NotesSkill
+from .skills.base import Skill, _normalize
+from .history import append_history
+from .telemetry import log_record_var
+
+
+CATALOG_PATH = Path(__file__).parent / "skills" / "keyword_catalog.json"
+
+_SKILL_CLASSES: Dict[str, Type[Skill]] = {
+    "MathSkill": MathSkill,
+    "TranslateSkill": TranslateSkill,
+    "SearchSkill": SearchSkill,
+    "TimerSkill": TimerSkill,
+    "NotesSkill": NotesSkill,
+}
+
+
+def _load_catalog() -> Dict[Type[Skill], List[str]]:
+    with CATALOG_PATH.open("r", encoding="utf-8") as fh:
+        raw = json.load(fh)
+    cat: Dict[Type[Skill], List[str]] = {}
+    for name, words in raw.items():
+        cls = _SKILL_CLASSES.get(name)
+        if cls is not None:
+            cat[cls] = [w.lower() for w in words]
+    return cat
+
+
+KEYWORD_CATALOG = _load_catalog()
+
+
+async def check_keyword_catalog(prompt: str) -> Optional[str]:
+    """Return skill response if prompt matches keyword catalog."""
+    norm = _normalize(prompt)
+    low = norm.lower()
+    for cls, keywords in KEYWORD_CATALOG.items():
+        if any(k in low for k in keywords):
+            skill = cls()
+            m = skill.match(norm)
+            if not m:
+                continue
+            resp = await skill.run(prompt, m)
+            rec = log_record_var.get()
+            if rec is not None:
+                rec.matched_skill = cls.__name__
+                rec.match_confidence = 1.0
+                rec.engine_used = cls.__name__
+                rec.response = str(resp)
+            await append_history(prompt, cls.__name__, str(resp))
+            return resp
+    return None

--- a/app/router.py
+++ b/app/router.py
@@ -5,8 +5,9 @@ from .llama_integration import ask_llama, OLLAMA_MODEL, LLAMA_HEALTHY
 from .gpt_client import ask_gpt, OPENAI_MODEL
 from .home_assistant import handle_command
 from .intent_detector import detect_intent
-from .analytics import record                # ⬅︎ kept as‑is
-from .history import append_history          # ⬅︎ signature unchanged
+from .keyword_catalog import check_keyword_catalog
+from .analytics import record  # ⬅︎ kept as‑is
+from .history import append_history  # ⬅︎ signature unchanged
 from .telemetry import log_record_var
 
 logger = logging.getLogger(__name__)
@@ -27,6 +28,10 @@ async def route_prompt(prompt: str, model_override: str | None = None) -> Any:
         await append_history(prompt, "ha", str(ha_resp))
         print("✅ HA response logged.")
         return ha_resp
+
+    catalog_resp = await check_keyword_catalog(prompt)
+    if catalog_resp is not None:
+        return catalog_resp
 
     if model_override:
         would_use_llama = model_override.lower().startswith("llama")

--- a/app/skills/keyword_catalog.json
+++ b/app/skills/keyword_catalog.json
@@ -1,0 +1,7 @@
+{
+    "MathSkill": ["+", "-", "*", "x", "×", "/", "% of", "round"],
+    "TranslateSkill": ["translate", "detect language"],
+    "SearchSkill": ["search", "who is", "what is"],
+    "TimerSkill": ["timer"],
+    "NotesSkill": ["note", "notes"]
+}

--- a/tests/test_ask_skills.py
+++ b/tests/test_ask_skills.py
@@ -1,6 +1,7 @@
 import os, sys
 import asyncio
 from fastapi.testclient import TestClient
+
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 
@@ -9,21 +10,25 @@ def setup_app(monkeypatch):
     os.environ["OLLAMA_MODEL"] = "llama3"
     os.environ["HOME_ASSISTANT_URL"] = "http://ha"
     os.environ["HOME_ASSISTANT_TOKEN"] = "token"
-    from app import main
+    from app import main, router
+
     monkeypatch.setattr(main, "ha_startup", lambda: None)
     monkeypatch.setattr(main, "llama_startup", lambda: None)
-    called = {"route": False}
-    async def fake_route(prompt, model=None):
-        called["route"] = True
+    called = {"llm": False}
+
+    async def fake_llm(prompt, model=None):
+        called["llm"] = True
         return "llm"
-    monkeypatch.setattr(main, "route_prompt", fake_route)
+
+    monkeypatch.setattr(router, "ask_llama", fake_llm)
+    monkeypatch.setattr(router, "ask_gpt", fake_llm)
     return main, called
 
 
-def test_clock_skill_shortcuts(monkeypatch):
+def test_keyword_catalog_shortcuts(monkeypatch):
     main, called = setup_app(monkeypatch)
     client = TestClient(main.app)
-    resp = client.post("/ask", json={"prompt": "what time is it?"})
+    resp = client.post("/ask", json={"prompt": "2 + 2"})
     assert resp.status_code == 200
-    assert "time" in resp.json()["response"].lower()
-    assert not called["route"]
+    assert resp.json()["response"] == "4"
+    assert not called["llm"]


### PR DESCRIPTION
## Summary
- add `keyword_catalog.json` with trigger words
- implement catalog checking logic
- refactor `route_prompt` to use catalog before LLMs
- remove skill pre-checks from `ask` endpoint
- adjust tests to exercise new routing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68896f5354ac832aba8047038091f977