### PR TITLE
Add session capture and realtime transcription API

### DIFF
--- a/app/router.py
+++ b/app/router.py
@@ -95,6 +95,7 @@ async def route_prompt(prompt: str, model_override: str | None = None) -> Any:
         gpt_model = OPENAI_MODEL
 
     use_llama = use_llama_pref and LLAMA_HEALTHY
+    fallback_used = use_llama_pref
     chosen_model = llama_model if use_llama else gpt_model
     engine_used = "llama" if use_llama else "gpt"
 
@@ -141,6 +142,6 @@ async def route_prompt(prompt: str, model_override: str | None = None) -> Any:
         rec.cost_usd = ((pt or 0) + (ct or 0)) / 1000 * unit_price
 
     await append_history(prompt, "gpt", text)
-    await record("gpt", fallback=use_llama)
+    await record("gpt", fallback=fallback_used)
     logger.debug("GPT responded OK with %s", final_model)
     return text

--- a/app/session_manager.py
+++ b/app/session_manager.py
@@ -1,0 +1,151 @@
+import os
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Any, List
+
+from fastapi import UploadFile
+
+from .history import append_history
+from .telemetry import LogRecord
+
+# Base directory for session storage
+SESSIONS_DIR = Path(os.getenv("SESSIONS_DIR", Path(__file__).parent.parent / "sessions"))
+SESSIONS_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def _session_path(session_id: str) -> Path:
+    return SESSIONS_DIR / session_id
+
+
+def _meta_path(session_id: str) -> Path:
+    return _session_path(session_id) / "meta.json"
+
+
+def _load_meta(session_id: str) -> dict[str, Any]:
+    mp = _meta_path(session_id)
+    if mp.exists():
+        return json.loads(mp.read_text(encoding="utf-8"))
+    return {}
+
+
+def _save_meta(session_id: str, meta: dict[str, Any]) -> None:
+    mp = _meta_path(session_id)
+    mp.parent.mkdir(parents=True, exist_ok=True)
+    mp.write_text(json.dumps(meta, ensure_ascii=False, indent=2), encoding="utf-8")
+
+
+async def start_session() -> dict[str, str]:
+    """Create a new session folder and meta.json entry."""
+    ts = datetime.utcnow().isoformat(timespec="seconds")
+    session_id = ts.replace(":", "-")
+    session_dir = _session_path(session_id)
+    session_dir.mkdir(parents=True, exist_ok=True)
+    meta = {
+        "session_id": session_id,
+        "status": "started",
+        "created_at": ts + "Z",
+        "errors": [],
+    }
+    _save_meta(session_id, meta)
+    rec = LogRecord(req_id="session", session_id=session_id, prompt="session_start")
+    await append_history(rec)
+    return {"session_id": session_id, "path": str(session_dir)}
+
+
+async def save_session(
+    session_id: str,
+    audio: UploadFile | None = None,
+    video: UploadFile | None = None,
+    transcript: str | None = None,
+) -> None:
+    """Persist provided media and queue jobs."""
+    session_dir = _session_path(session_id)
+    if not session_dir.exists():
+        raise FileNotFoundError("session not found")
+    meta = _load_meta(session_id)
+    meta["status"] = "saving"
+    _save_meta(session_id, meta)
+
+    if audio is not None:
+        data = await audio.read()
+        (session_dir / "audio.wav").write_bytes(data)
+    if video is not None:
+        data = await video.read()
+        (session_dir / "video.mp4").write_bytes(data)
+    if transcript is not None:
+        (session_dir / "transcript.txt").write_text(transcript, encoding="utf-8")
+
+    meta["status"] = "saved"
+    _save_meta(session_id, meta)
+
+    if transcript is None:
+        from .tasks import enqueue_transcription
+        enqueue_transcription(session_id)
+    else:
+        from .tasks import enqueue_tag_extraction
+        enqueue_tag_extraction(session_id)
+
+
+async def generate_tags(session_id: str) -> None:
+    from .tasks import enqueue_tag_extraction
+
+    enqueue_tag_extraction(session_id)
+
+
+async def search_sessions(query: str) -> List[dict[str, Any]]:
+    q = query.lower()
+    results: List[dict[str, Any]] = []
+    for sess_dir in SESSIONS_DIR.iterdir():
+        if not sess_dir.is_dir():
+            continue
+        sid = sess_dir.name
+        score = 0
+        tfile = sess_dir / "transcript.txt"
+        if tfile.exists():
+            text = tfile.read_text(encoding="utf-8").lower()
+            if q in text:
+                score += 1
+        tagfile = sess_dir / "tags.json"
+        if tagfile.exists():
+            try:
+                tags = json.loads(tagfile.read_text(encoding="utf-8"))
+                if any(q in str(tag).lower() for tag in tags):
+                    score += 1
+            except Exception:
+                pass
+        if score:
+            results.append({"session_id": sid, "score": score})
+    return results
+
+
+# helper for tag extraction -----------------------------------------------------
+
+def extract_tags_from_text(text: str) -> List[str]:
+    """Return a simple list of tags from text using spaCy if available."""
+    try:  # spaCy is optional
+        import spacy
+
+        try:
+            nlp = spacy.load("en_core_web_sm")
+        except Exception:
+            nlp = spacy.blank("en")
+        doc = nlp(text)
+        tokens = []
+        for t in doc:
+            if t.is_alpha and not t.is_stop:
+                lemma = t.lemma_ if t.lemma_ else t.text
+                tokens.append(lemma.lower())
+    except Exception:
+        tokens = [t.lower() for t in text.split() if t.isalpha()]
+    return sorted(set(tokens))
+
+
+__all__ = [
+    "SESSIONS_DIR",
+    "start_session",
+    "save_session",
+    "generate_tags",
+    "search_sessions",
+    "extract_tags_from_text",
+]

--- a/app/skills/math_skill.py
+++ b/app/skills/math_skill.py
@@ -6,8 +6,8 @@ from .base import Skill
 class MathSkill(Skill):
     PATTERNS = [
         re.compile(r"(?P<a>\d+(?:\.\d+)?)\s*(?P<op>[+\-*/x×])\s*(?P<b>\d+(?:\.\d+)?)", re.I),
-        re.compile(r"(?P<pct>\d+(?:\.\d+)?)%\\s*of\\s*(?P<of>\\d+(?:\\.\\d+)?)", re.I),
-        re.compile(r"round\\s+(?P<val>\\d+(?:\\.\\d+)?)\\s+to\\s+(?P<places>\\d+)\\s+decimal", re.I),
+        re.compile(r"(?P<pct>\d+(?:\.\d+)?)%\s*of\s*(?P<of>\d+(?:\.\d+)?)", re.I),
+        re.compile(r"round\s+(?P<val>\d+(?:\.\d+)?)\s+to\s+(?P<places>\d+)\s+decimal", re.I),
     ]
 
     async def run(self, prompt: str, match: re.Match) -> str:

--- a/app/skills/search_skill.py
+++ b/app/skills/search_skill.py
@@ -15,7 +15,7 @@ class SearchSkill(Skill):
 
     async def run(self, prompt: str, match: re.Match) -> str:
         query = match.group("query").strip()
-        async with httpx.AsyncClient() as client:
+        async with httpx.AsyncClient(timeout=5.0) as client:
             resp = await client.get(
                 "https://api.duckduckgo.com/",
                 params={
@@ -24,7 +24,6 @@ class SearchSkill(Skill):
                     "no_redirect": "1",
                     "no_html": "1",
                 },
-                timeout=5.0,
             )
             resp.raise_for_status()
             data = resp.json()

--- a/app/tasks.py
+++ b/app/tasks.py
@@ -1,0 +1,83 @@
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+try:
+    from redis import Redis
+    from rq import Queue
+except Exception:  # pragma: no cover - optional dependency
+    Redis = None
+    Queue = None
+
+from .session_manager import (
+    SESSIONS_DIR,
+    _load_meta,
+    _save_meta,
+    extract_tags_from_text,
+)
+from .transcribe import transcribe_file as sync_transcribe_file
+
+
+def _get_queue() -> Queue:
+    if Redis is None or Queue is None:
+        raise RuntimeError("redis/rq not installed")
+    url = os.getenv("REDIS_URL", "redis://localhost:6379/0")
+    conn = Redis.from_url(url)
+    return Queue("default", connection=conn)
+
+
+def enqueue_transcription(session_id: str) -> None:
+    try:
+        q = _get_queue()
+        q.enqueue(transcribe_task, session_id)
+    except Exception:
+        transcribe_task(session_id)
+
+
+def enqueue_tag_extraction(session_id: str) -> None:
+    try:
+        q = _get_queue()
+        q.enqueue(tag_task, session_id)
+    except Exception:
+        tag_task(session_id)
+
+
+def transcribe_task(session_id: str) -> None:
+    session_dir = SESSIONS_DIR / session_id
+    audio_path = session_dir / "audio.wav"
+    transcript_path = session_dir / "transcript.txt"
+    meta = _load_meta(session_id)
+    try:
+        text = sync_transcribe_file(str(audio_path))
+        transcript_path.write_text(text, encoding="utf-8")
+        meta["status"] = "transcribed"
+    except Exception as e:  # pragma: no cover - network errors
+        meta.setdefault("errors", []).append(str(e))
+        meta["status"] = "error"
+    _save_meta(session_id, meta)
+
+
+def tag_task(session_id: str) -> None:
+    session_dir = SESSIONS_DIR / session_id
+    transcript_path = session_dir / "transcript.txt"
+    tags_path = session_dir / "tags.json"
+    meta = _load_meta(session_id)
+    try:
+        text = transcript_path.read_text(encoding="utf-8")
+        tags = extract_tags_from_text(text)
+        tags_path.write_text(json.dumps(tags, ensure_ascii=False, indent=2), encoding="utf-8")
+        meta["tags"] = tags
+        meta["status"] = "tagged"
+    except Exception as e:  # pragma: no cover - nlp errors
+        meta.setdefault("errors", []).append(str(e))
+        meta["status"] = "error"
+    _save_meta(session_id, meta)
+
+
+__all__ = [
+    "enqueue_transcription",
+    "enqueue_tag_extraction",
+    "transcribe_task",
+    "tag_task",
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,6 @@ aiofiles
 numpy
 scipy
 python-multipart
+redis
+rq
+spacy

--- a/tests/test_sessions_api.py
+++ b/tests/test_sessions_api.py
@@ -1,0 +1,57 @@
+import json
+import json
+import os
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+os.environ.setdefault("OLLAMA_URL", "http://x")
+os.environ.setdefault("OLLAMA_MODEL", "llama3")
+os.environ.setdefault("HOME_ASSISTANT_URL", "http://ha")
+os.environ.setdefault("HOME_ASSISTANT_TOKEN", "token")
+
+from app.main import app
+import app.session_manager as sm
+import app.tasks as tasks
+import app.main as main
+
+
+def setup_temp(monkeypatch, tmp_path: Path):
+    monkeypatch.setattr(main, "ha_startup", lambda: None)
+    monkeypatch.setattr(main, "llama_startup", lambda: None)
+    monkeypatch.setattr(sm, "SESSIONS_DIR", tmp_path)
+    monkeypatch.setattr(tasks, "SESSIONS_DIR", tmp_path)
+    monkeypatch.setattr(main, "SESSIONS_DIR", tmp_path)
+
+
+def test_capture_flow(monkeypatch, tmp_path):
+    setup_temp(monkeypatch, tmp_path)
+    client = TestClient(app)
+
+    resp = client.post("/capture/start")
+    assert resp.status_code == 200
+    data = resp.json()
+    session_id = data["session_id"]
+    sess_dir = tmp_path / session_id
+    assert sess_dir.exists()
+
+    files = {"audio": ("a.wav", b"data")}
+    resp = client.post(
+        "/capture/save",
+        data={"session_id": session_id, "transcript": "hello world"},
+        files=files,
+    )
+    assert resp.status_code == 200
+
+    resp = client.post("/capture/tags", data={"session_id": session_id})
+    assert resp.status_code == 200
+
+    tag_file = sess_dir / "tags.json"
+    assert tag_file.exists()
+    tags = json.loads(tag_file.read_text())
+    assert "hello" in tags
+
+    resp = client.get("/search/sessions", params={"q": "hello"})
+    assert resp.status_code == 200
+    results = resp.json()
+    assert any(r["session_id"] == session_id for r in results)


### PR DESCRIPTION
## Summary
- scaffold session manager for storing audio, video, transcripts and tags with searchable metadata
- add Redis/RQ-backed tasks for transcription and tag extraction
- expose capture, search and websocket transcription endpoints
- fix router fallback metrics and polish math/search skills
- cover session flow with new test

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688ac3e902a4832abe3dc5e0942e6c7d