### PR TITLE
Add auth, rate limiting, and session analytics

### DIFF
--- a/app/analytics.py
+++ b/app/analytics.py
@@ -1,7 +1,16 @@
 import asyncio
 from typing import Dict
 
-_metrics = {"total": 0, "llama": 0, "gpt": 0, "fallback": 0}
+_metrics = {
+    "total": 0,
+    "llama": 0,
+    "gpt": 0,
+    "fallback": 0,
+    "session_count": 0,
+    "transcribe_ms": 0,
+    "transcribe_count": 0,
+    "transcribe_errors": 0,
+}
 _lock = asyncio.Lock()
 
 
@@ -14,6 +23,19 @@ async def record(engine: str, fallback: bool = False) -> None:
             _metrics["gpt"] += 1
         if fallback:
             _metrics["fallback"] += 1
+
+
+async def record_session() -> None:
+    async with _lock:
+        _metrics["session_count"] += 1
+
+
+async def record_transcription(duration_ms: int, error: bool = False) -> None:
+    async with _lock:
+        _metrics["transcribe_count"] += 1
+        _metrics["transcribe_ms"] += max(duration_ms, 0)
+        if error:
+            _metrics["transcribe_errors"] += 1
 
 
 def get_metrics() -> Dict[str, int]:

--- a/app/security.py
+++ b/app/security.py
@@ -1,0 +1,53 @@
+import os
+import time
+import asyncio
+from typing import Dict, List
+from fastapi import Request, HTTPException, WebSocket
+
+API_TOKEN = os.getenv("API_TOKEN")
+RATE_LIMIT = int(os.getenv("RATE_LIMIT_PER_MIN", "60"))
+_window = 60.0
+_lock = asyncio.Lock()
+_requests: Dict[str, List[float]] = {}
+
+async def verify_token(request: Request) -> None:
+    if not API_TOKEN:
+        return
+    auth = request.headers.get("Authorization")
+    expected = f"Bearer {API_TOKEN}"
+    if auth != expected:
+        raise HTTPException(status_code=401, detail="Unauthorized")
+
+async def rate_limit(request: Request) -> None:
+    ip = request.client.host if request.client else "anon"
+    now = time.time()
+    async with _lock:
+        timestamps = _requests.setdefault(ip, [])
+        fresh = [ts for ts in timestamps if now - ts < _window]
+        if len(fresh) >= RATE_LIMIT:
+            raise HTTPException(status_code=429, detail="Rate limit exceeded")
+        fresh.append(now)
+        _requests[ip] = fresh
+
+
+async def verify_ws(ws: WebSocket) -> None:
+    if not API_TOKEN:
+        return
+    auth = ws.headers.get("Authorization")
+    expected = f"Bearer {API_TOKEN}"
+    if auth != expected:
+        await ws.close(code=1008)
+        raise HTTPException(status_code=1008, detail="Unauthorized")
+
+
+async def rate_limit_ws(ws: WebSocket) -> None:
+    ip = ws.client.host if ws.client else "anon"
+    now = time.time()
+    async with _lock:
+        timestamps = _requests.setdefault(ip, [])
+        fresh = [ts for ts in timestamps if now - ts < _window]
+        if len(fresh) >= RATE_LIMIT:
+            await ws.close(code=1013)
+            raise HTTPException(status_code=1013, detail="Rate limit exceeded")
+        fresh.append(now)
+        _requests[ip] = fresh

--- a/tests/test_llama_health.py
+++ b/tests/test_llama_health.py
@@ -60,8 +60,20 @@ def test_router_skips_when_unhealthy(monkeypatch):
     monkeypatch.setattr(router, "detect_intent", lambda p: ("chat", "high"))
     monkeypatch.setattr(router, "ask_llama", fake_llama)
     monkeypatch.setattr(router, "ask_gpt", fake_gpt)
-    analytics._metrics = {"total": 0, "llama": 0, "gpt": 0, "fallback": 0}
+    analytics._metrics = {
+        "total": 0,
+        "llama": 0,
+        "gpt": 0,
+        "fallback": 0,
+        "session_count": 0,
+        "transcribe_ms": 0,
+        "transcribe_count": 0,
+        "transcribe_errors": 0,
+    }
 
     result = asyncio.run(router.route_prompt("hello"))
     assert result == "ok"
-    assert analytics.get_metrics() == {"total": 1, "llama": 0, "gpt": 1, "fallback": 1}
+    m = analytics.get_metrics()
+    assert m["total"] == 1
+    assert m["gpt"] == 1
+    assert m["fallback"] == 1

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -20,8 +20,20 @@ def test_router_fallback_metrics_updated(monkeypatch):
     monkeypatch.setattr(router, "detect_intent", lambda p: ("chat", "high"))
     monkeypatch.setattr(router, "ask_llama", fake_llama)
     monkeypatch.setattr(router, "ask_gpt", fake_gpt)
-    analytics._metrics = {"total": 0, "llama": 0, "gpt": 0, "fallback": 0}
+    analytics._metrics = {
+        "total": 0,
+        "llama": 0,
+        "gpt": 0,
+        "fallback": 0,
+        "session_count": 0,
+        "transcribe_ms": 0,
+        "transcribe_count": 0,
+        "transcribe_errors": 0,
+    }
 
     result = asyncio.run(router.route_prompt("hello"))
     assert result == "ok"
-    assert analytics.get_metrics() == {"total": 1, "llama": 0, "gpt": 1, "fallback": 1}
+    m = analytics.get_metrics()
+    assert m["total"] == 1
+    assert m["gpt"] == 1
+    assert m["fallback"] == 1

--- a/tests/test_sessions_api.py
+++ b/tests/test_sessions_api.py
@@ -22,28 +22,34 @@ def setup_temp(monkeypatch, tmp_path: Path):
     monkeypatch.setattr(sm, "SESSIONS_DIR", tmp_path)
     monkeypatch.setattr(tasks, "SESSIONS_DIR", tmp_path)
     monkeypatch.setattr(main, "SESSIONS_DIR", tmp_path)
+    monkeypatch.setenv("API_TOKEN", "secret")
 
 
 def test_capture_flow(monkeypatch, tmp_path):
     setup_temp(monkeypatch, tmp_path)
     client = TestClient(app)
 
-    resp = client.post("/capture/start")
+    headers = {"Authorization": "Bearer secret"}
+    resp = client.post("/capture/start", headers=headers)
     assert resp.status_code == 200
     data = resp.json()
     session_id = data["session_id"]
     sess_dir = tmp_path / session_id
     assert sess_dir.exists()
 
-    files = {"audio": ("a.wav", b"data")}
+    files = {"audio": ("a.wav", b"data", "audio/wav")}
     resp = client.post(
         "/capture/save",
         data={"session_id": session_id, "transcript": "hello world"},
         files=files,
+        headers=headers,
     )
     assert resp.status_code == 200
+    assert resp.json()["status"] in {"saved", "tagged"}
 
-    resp = client.post("/capture/tags", data={"session_id": session_id})
+    resp = client.post(
+        "/capture/tags", data={"session_id": session_id}, headers=headers
+    )
     assert resp.status_code == 200
 
     tag_file = sess_dir / "tags.json"
@@ -51,7 +57,11 @@ def test_capture_flow(monkeypatch, tmp_path):
     tags = json.loads(tag_file.read_text())
     assert "hello" in tags
 
-    resp = client.get("/search/sessions", params={"q": "hello"})
+    resp = client.get("/search/sessions", params={"q": "hello"}, headers=headers)
     assert resp.status_code == 200
     results = resp.json()
-    assert any(r["session_id"] == session_id for r in results)
+    assert any(r["session_id"] == session_id and "snippet" in r for r in results)
+
+    resp = client.get(f"/capture/status/{session_id}", headers=headers)
+    assert resp.status_code == 200
+    assert resp.json()["status"] in {"saved", "tagged"}

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -20,7 +20,20 @@ def test_status_endpoint(monkeypatch):
     monkeypatch.setattr(llama_integration, "startup_check", lambda: None)
     monkeypatch.setattr(status, "_request", fake_request)
     monkeypatch.setattr(status, "llama_get_status", fake_llama_status)
-    monkeypatch.setattr(status, "get_metrics", lambda: {"total": 1, "llama": 1, "gpt": 0, "fallback": 0})
+    monkeypatch.setattr(
+        status,
+        "get_metrics",
+        lambda: {
+            "total": 1,
+            "llama": 1,
+            "gpt": 0,
+            "fallback": 0,
+            "session_count": 0,
+            "transcribe_ms": 0,
+            "transcribe_count": 0,
+            "transcribe_errors": 0,
+        },
+    )
 
     client = TestClient(main.app)
     resp = client.get("/status")

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -13,10 +13,14 @@ def test_upload_saves_file(tmp_path, monkeypatch):
     monkeypatch.setattr(main, "ha_startup", lambda: None)
     monkeypatch.setattr(main, "llama_startup", lambda: None)
     monkeypatch.setattr(main, "SESSIONS_DIR", str(tmp_path))
+    monkeypatch.setenv("API_TOKEN", "secret")
 
     client = TestClient(main.app)
     data = b"abc"
-    resp = client.post("/upload", files={"file": ("foo.wav", data, "audio/wav")})
+    headers = {"Authorization": "Bearer secret"}
+    resp = client.post(
+        "/upload", files={"file": ("foo.wav", data, "audio/wav")}, headers=headers
+    )
     assert resp.status_code == 200
     sid = resp.json()["session_id"]
     saved = tmp_path / sid / "source.wav"


### PR DESCRIPTION
## Summary
- enforce bearer-token auth and per-IP rate limits across upload, capture, search, and websocket routes
- expose session metadata via `/capture/status`, include it in save responses, and guard uploads by size & MIME
- track session and transcription metrics while streaming transcription incrementally

## Testing
- `PYENV_VERSION=3.11.12 python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_688acbbcfac4832a8bdbb0e7216cf7f1