### PR TITLE
Add session search pagination and retention utilities

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -212,10 +212,13 @@ async def capture_status(
 @app.get("/search/sessions")
 async def search_sessions(
     q: str,
+    sort: str = "recent",
+    page: int = 1,
+    limit: int = 10,
     _: None = Depends(verify_token),
     __: None = Depends(rate_limit),
 ):
-    return await search_session_store(q)
+    return await search_session_store(q, sort=sort, page=page, limit=limit)
 
 
 @app.websocket("/transcribe")

--- a/tests/test_retention.py
+++ b/tests/test_retention.py
@@ -1,0 +1,29 @@
+import json
+from datetime import datetime
+
+import app.session_manager as sm
+
+def test_archive_old_sessions(tmp_path, monkeypatch):
+    monkeypatch.setattr(sm, "SESSIONS_DIR", tmp_path)
+    old_id = "2023-01-01T00-00-00"
+    old_dir = tmp_path / old_id
+    old_dir.mkdir()
+    meta_old = {"session_id": old_id, "created_at": "2023-01-01T00:00:00Z", "status": "tagged"}
+    (old_dir / "meta.json").write_text(json.dumps(meta_old))
+    (old_dir / "transcript.txt").write_text("hello", encoding="utf-8")
+
+    recent_id = "recent"
+    recent_dir = tmp_path / recent_id
+    recent_dir.mkdir()
+    meta_recent = {
+        "session_id": recent_id,
+        "created_at": datetime.utcnow().isoformat(timespec="seconds") + "Z",
+        "status": "tagged",
+    }
+    (recent_dir / "meta.json").write_text(json.dumps(meta_recent))
+
+    archived = sm.archive_old_sessions(days=90)
+    assert (tmp_path / "archive" / f"{old_id}.tar.gz").exists()
+    assert not (tmp_path / old_id).exists()
+    assert recent_dir.exists()
+    assert archived


### PR DESCRIPTION
## Summary
- support dict-style entries in history file
- stream large uploads with checksum, immediate tagging, and session history logging
- extend session search with pagination and recency sort
- add archival helper for old sessions
- exercise session search and archival utilities in tests

## Testing
- `PYENV_VERSION=3.11.12 python -m pytest tests/test_sessions_api.py::test_search_sort_and_pagination tests/test_retention.py::test_archive_old_sessions`


------
https://chatgpt.com/codex/tasks/task_e_688ad3ae7304832aa946a6fbf75b03ba