### PR TITLE
Add tests for websocket transcription and tagging

### DIFF
--- a/tests/test_sessions_api.py
+++ b/tests/test_sessions_api.py
@@ -100,3 +100,23 @@ def test_search_sort_and_pagination(monkeypatch, tmp_path):
     results = resp.json()
     assert len(results) == 1
     assert results[0]["session_id"] == "2023-01-02T00-00-00"
+
+def test_search_by_tag(monkeypatch, tmp_path):
+    setup_temp(monkeypatch, tmp_path)
+    headers = {"Authorization": "Bearer secret"}
+    sid = "tagonly"
+    sd = tmp_path / sid
+    sd.mkdir()
+    (sd / "transcript.txt").write_text("nothing", encoding="utf-8")
+    (sd / "tags.json").write_text(json.dumps(["special"]))
+    meta = {"session_id": sid, "created_at": "2023-01-01T00:00:00Z", "status": "tagged"}
+    (sd / "meta.json").write_text(json.dumps(meta))
+    client = TestClient(app)
+    resp = client.get(
+        "/search/sessions",
+        params={"q": "special"},
+        headers=headers,
+    )
+    assert resp.status_code == 200
+    results = resp.json()
+    assert any(r["session_id"] == sid for r in results)

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,0 +1,18 @@
+import os
+from app import tasks
+
+def test_enqueue_fallback(monkeypatch):
+    called = []
+
+    def raise_err():
+        raise RuntimeError("no redis")
+
+    monkeypatch.setattr(tasks, "_get_queue", raise_err)
+    monkeypatch.setattr(tasks, "transcribe_task", lambda sid: called.append(("t", sid)))
+    tasks.enqueue_transcription("abc")
+    assert called == [("t", "abc")]
+
+    called.clear()
+    monkeypatch.setattr(tasks, "tag_task", lambda sid: called.append(("g", sid)))
+    tasks.enqueue_tag_extraction("xyz")
+    assert called == [("g", "xyz")]

--- a/tests/test_transcribe_ws.py
+++ b/tests/test_transcribe_ws.py
@@ -1,0 +1,39 @@
+import os
+from fastapi.testclient import TestClient
+
+
+def setup_app(monkeypatch, tmp_path):
+    os.environ.setdefault("OLLAMA_URL", "http://x")
+    os.environ.setdefault("OLLAMA_MODEL", "llama3")
+    os.environ.setdefault("HOME_ASSISTANT_URL", "http://ha")
+    os.environ.setdefault("HOME_ASSISTANT_TOKEN", "token")
+    os.environ["API_TOKEN"] = "secret"
+    from app import main
+    monkeypatch.setattr(main, "ha_startup", lambda: None)
+    monkeypatch.setattr(main, "llama_startup", lambda: None)
+    monkeypatch.setattr(main, "SESSIONS_DIR", tmp_path)
+    return main
+
+
+def test_websocket_transcription(monkeypatch, tmp_path):
+    main = setup_app(monkeypatch, tmp_path)
+
+    async def fake_transcribe(path: str) -> str:
+        return "hello"
+
+    monkeypatch.setattr(main, "transcribe_file", fake_transcribe)
+
+    client = TestClient(main.app)
+    with client.websocket_connect(
+        "/transcribe", headers={"Authorization": "Bearer secret"}
+    ) as ws:
+        ws.send_json({"rate": 16000})
+        ws.send_bytes(b"audio")
+        data = ws.receive_json()
+        assert data["text"] == "hello"
+        session_id = data["session_id"]
+        ws.send_text("end")
+
+    audio_path = tmp_path / session_id / "stream.wav"
+    assert audio_path.exists()
+    assert audio_path.read_bytes() == b"audio"


### PR DESCRIPTION
## Summary
- add websocket transcription test ensuring streamed audio is saved and captioned
- cover task queue fallback when Redis is unavailable
- verify search sessions finds tag-only matches

## Testing
- `~/.pyenv/versions/3.11.12/bin/python -m pytest tests/test_transcribe_ws.py tests/test_tasks.py tests/test_sessions_api.py -q`
- `~/.pyenv/versions/3.11.12/bin/python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688ad8efff4c832a891df319e61084d1