### PR TITLE
Fix routing overrides, complexity check, and session tags

### DIFF
--- a/app/analytics.py
+++ b/app/analytics.py
@@ -14,13 +14,14 @@ _metrics = {
 _lock = asyncio.Lock()
 
 
-async def record(engine: str, fallback: bool = False) -> None:
+async def record(engine: str, fallback: bool = False, source: str = "gpt") -> None:
     async with _lock:
         _metrics["total"] += 1
-        if engine == "llama":
-            _metrics["llama"] += 1
-        else:
-            _metrics["gpt"] += 1
+        if source == "gpt":
+            if engine == "llama":
+                _metrics["llama"] += 1
+            elif engine == "gpt":
+                _metrics["gpt"] += 1
         if fallback:
             _metrics["fallback"] += 1
 

--- a/app/main.py
+++ b/app/main.py
@@ -182,10 +182,12 @@ async def capture_save(
     audio: UploadFile | None = File(None),
     video: UploadFile | None = File(None),
     transcript: str | None = Form(None),
+    tags: str | None = Form(None),
     _: None = Depends(verify_token),
     __: None = Depends(rate_limit),
 ):
-    await finalize_capture_session(session_id, audio, video, transcript)
+    tags_list = json.loads(tags) if tags else None
+    await finalize_capture_session(session_id, audio, video, transcript, tags_list)
     return get_session_meta(session_id)
 
 

--- a/app/session_manager.py
+++ b/app/session_manager.py
@@ -80,6 +80,7 @@ async def save_session(
     audio: UploadFile | None = None,
     video: UploadFile | None = None,
     transcript: str | None = None,
+    tags: List[str] | None = None,
 ) -> None:
     """Persist provided media and queue jobs."""
     session_dir = _session_path(session_id)
@@ -105,10 +106,15 @@ async def save_session(
         )
         meta["video_checksum"] = checksum
 
-    tags: List[str] = []
+    tags = tags or []
     if transcript is not None:
         (session_dir / "transcript.txt").write_text(transcript, encoding="utf-8")
         meta["status"] = SessionStatus.TRANSCRIBED.value
+    if tags:
+        meta["tags"] = tags
+        (session_dir / "tags.json").write_text(
+            json.dumps(tags, ensure_ascii=False), encoding="utf-8"
+        )
     _save_meta(session_id, meta)
 
     record = {

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -3,6 +3,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 import pytest
 
 import asyncio
+from fastapi import HTTPException
 
 def test_router_fallback_metrics_updated(monkeypatch):
     os.environ["OLLAMA_URL"] = "http://x"
@@ -37,3 +38,90 @@ def test_router_fallback_metrics_updated(monkeypatch):
     assert m["total"] == 1
     assert m["gpt"] == 1
     assert m["fallback"] == 1
+
+
+def test_gpt_override(monkeypatch):
+    os.environ["OLLAMA_URL"] = "http://x"
+    os.environ["OLLAMA_MODEL"] = "llama3"
+    os.environ["HOME_ASSISTANT_URL"] = "http://ha"
+    os.environ["HOME_ASSISTANT_TOKEN"] = "token"
+    from app import router, llama_integration
+
+    llama_integration.LLAMA_HEALTHY = True
+
+    async def fake_gpt(prompt, model=None):
+        return model, 0, 0, 0.0
+
+    monkeypatch.setattr(router, "ask_gpt", fake_gpt)
+    monkeypatch.setattr(router, "ALLOWED_GPT_MODELS", {"gpt-4"})
+    result = asyncio.run(router.route_prompt("hi", "gpt-4"))
+    assert result == "gpt-4"
+
+
+def test_gpt_override_invalid(monkeypatch):
+    os.environ["OLLAMA_URL"] = "http://x"
+    os.environ["OLLAMA_MODEL"] = "llama3"
+    os.environ["HOME_ASSISTANT_URL"] = "http://ha"
+    os.environ["HOME_ASSISTANT_TOKEN"] = "token"
+    from app import router
+
+    monkeypatch.setattr(router, "ALLOWED_GPT_MODELS", {"gpt-4"})
+    with pytest.raises(HTTPException):
+        asyncio.run(router.route_prompt("hi", "gpt-3"))
+
+
+def test_complexity_checks(monkeypatch):
+    os.environ["OLLAMA_URL"] = "http://x"
+    os.environ["OLLAMA_MODEL"] = "llama3"
+    os.environ["HOME_ASSISTANT_URL"] = "http://ha"
+    os.environ["HOME_ASSISTANT_TOKEN"] = "token"
+    from app import router, llama_integration
+
+    llama_integration.LLAMA_HEALTHY = True
+
+    async def fake_gpt(prompt, model=None):
+        return "gpt", 0, 0, 0.0
+
+    async def fake_llama(prompt, model=None):
+        return "llama"
+
+    monkeypatch.setattr(router, "ask_gpt", fake_gpt)
+    monkeypatch.setattr(router, "ask_llama", fake_llama)
+
+    long_prompt = "word " * 31
+    assert asyncio.run(router.route_prompt(long_prompt)) == "gpt"
+
+    kw_prompt = "please analyze this"
+    assert asyncio.run(router.route_prompt(kw_prompt)) == "gpt"
+
+
+def test_skill_metrics(monkeypatch):
+    os.environ["OLLAMA_URL"] = "http://x"
+    os.environ["OLLAMA_MODEL"] = "llama3"
+    os.environ["HOME_ASSISTANT_URL"] = "http://ha"
+    os.environ["HOME_ASSISTANT_TOKEN"] = "token"
+    from app import router, analytics
+
+    class DummySkill:
+        name = "dummy"
+
+        async def handle(self, prompt):
+            return "done"
+
+    monkeypatch.setattr(router, "CATALOG", [(["dummy"], DummySkill)])
+    analytics._metrics = {
+        "total": 0,
+        "llama": 0,
+        "gpt": 0,
+        "fallback": 0,
+        "session_count": 0,
+        "transcribe_ms": 0,
+        "transcribe_count": 0,
+        "transcribe_errors": 0,
+    }
+    result = asyncio.run(router.route_prompt("dummy task"))
+    assert result == "done"
+    m = analytics.get_metrics()
+    assert m["total"] == 1
+    assert m["gpt"] == 0
+    assert m["llama"] == 0

--- a/tests/test_session_tags.py
+++ b/tests/test_session_tags.py
@@ -1,0 +1,27 @@
+import os, sys, json, asyncio
+from pathlib import Path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import pytest
+
+def test_save_session_tags(monkeypatch, tmp_path):
+    import app.session_manager as sm
+    import app.session_store as store
+
+    monkeypatch.setattr(sm, "SESSIONS_DIR", tmp_path)
+    monkeypatch.setattr(store, "SESSIONS_DIR", tmp_path)
+
+    async def noop(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(sm, "append_history", noop)
+
+    meta = store.create_session()
+    session_id = meta["session_id"]
+
+    asyncio.run(sm.save_session(session_id, transcript="hi", tags=["a", "b"]))
+
+    meta_after = store.load_meta(session_id)
+    assert meta_after.get("tags") == ["a", "b"]
+
+    tag_file = tmp_path / session_id / "tags.json"
+    assert json.loads(tag_file.read_text()) == ["a", "b"]


### PR DESCRIPTION
## Summary
- honor allowed GPT model overrides and apply word-count/keyword complexity check
- track skill vs GPT usage in analytics
- persist provided session tags through API

## Testing
- `PYENV_VERSION=3.11.12 python -m pytest tests/test_router.py tests/test_session_tags.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688d123d5778832aab0af2cefe965d65