### PR TITLE
Refactor memory cache for semantic lookups

### DIFF
--- a/app/memory/vector_store.py
+++ b/app/memory/vector_store.py
@@ -11,6 +11,7 @@ from chromadb.utils.embedding_functions import EmbeddingFunction
 
 class _LengthEmbeddingFunction(EmbeddingFunction):
     """Simple embedding based on text length to avoid heavy models."""
+
     def __call__(self, texts: List[str]) -> List[List[float]]:
         return [[float(len(t))] for t in texts]
 
@@ -19,16 +20,34 @@ class _LengthEmbeddingFunction(EmbeddingFunction):
 _client = chromadb.Client(Settings(anonymized_telemetry=False))
 _user_memories = _client.get_or_create_collection(
     "user_memories",
-    embedding_function=_LengthEmbeddingFunction()
+    embedding_function=_LengthEmbeddingFunction(),
 )
-_qa_cache = _client.get_or_create_collection(
-    "qa_cache",
-    embedding_function=_LengthEmbeddingFunction()
+
+
+class _SafeCollection:
+    """Wrapper around a ChromaDB collection that tolerates empty deletes."""
+
+    def __init__(self, col):
+        self._col = col
+
+    def delete(self, ids=None, **kwargs):
+        if not ids:
+            return
+        return self._col.delete(ids=ids, **kwargs)
+
+    def __getattr__(self, name):
+        return getattr(self._col, name)
+
+
+_qa_cache = _SafeCollection(
+    _client.get_or_create_collection(
+        "qa_cache", embedding_function=_LengthEmbeddingFunction()
+    )
 )
 
 
 def _cache_disabled() -> bool:
-    return bool(os.getenv("DISABLE_QA_CACHE") or os.getenv("PYTEST_CURRENT_TEST"))
+    return bool(os.getenv("DISABLE_QA_CACHE"))
 
 
 def add_user_memory(user_id: str, memory: str) -> str:
@@ -52,67 +71,71 @@ def query_user_memories(user_id: str, query: str, n_results: int = 5) -> List[st
     return results.get("documents", [[]])[0]
 
 
-def cache_answer(prompt: str, answer: str) -> None:
-    """
-    Cache an answer keyed by a hash of the prompt.
-    Includes timestamp for TTL and placeholder for user feedback.
+def cache_answer(*args: str) -> None:
+    """Store an answer in the semantic cache.
+
+    Supports ``cache_answer(prompt, answer)`` or
+    ``cache_answer(cache_id, prompt, answer)``.
     """
     if _cache_disabled():
         return
-    prompt_hash = hashlib.sha256(prompt.encode("utf-8")).hexdigest()
+    if len(args) == 2:
+        cache_id, prompt, answer = args[0], args[0], args[1]
+    elif len(args) == 3:
+        cache_id, prompt, answer = args
+    else:
+        raise TypeError("cache_answer expects 2 or 3 string arguments")
+
     _qa_cache.upsert(
-        ids=[prompt_hash],
-        documents=[answer],
-        metadatas=[{"timestamp": time.time(), "feedback": None}],
+        ids=[cache_id],
+        documents=[prompt],
+        metadatas=[{"answer": answer, "timestamp": time.time(), "feedback": None}],
     )
 
 
 def lookup_cached_answer(prompt: str, ttl_seconds: int = 86400) -> Optional[str]:
-    """
-    Retrieve a cached answer by prompt, respecting TTL and feedback.
-    Returns None if not found, expired, or flagged down.
-    """
+    """Retrieve a cached answer most similar to ``prompt``."""
+
     if _cache_disabled():
         return None
 
-    prompt_hash = hashlib.sha256(prompt.encode("utf-8")).hexdigest()
-    result = _qa_cache.get(ids=[prompt_hash])
-    docs = result.get("documents", [])
-    metas = result.get("metadatas", [])
-
-    if not docs or not docs[0]:
+    result = _qa_cache.query(query_texts=[prompt], n_results=1)
+    ids = result.get("ids", [[]])[0]
+    metas = result.get("metadatas", [[]])[0]
+    if not ids or not metas:
         return None
 
+    cache_id = ids[0]
     meta = metas[0] or {}
+    answer = meta.get("answer")
     fb = meta.get("feedback")
     ts = meta.get("timestamp", 0)
 
-    # Purge if negative feedback or expired
     if fb == "down" or (ts and time.time() - ts > ttl_seconds):
         try:
-            _qa_cache.delete(ids=[prompt_hash])
+            _qa_cache.delete(ids=[cache_id])
         finally:
             return None
 
-    return docs[0]
+    return answer
 
 
 def record_feedback(prompt: str, feedback: str) -> None:
-    """
-    Record user feedback ('up' or 'down') for a cached answer.
-    Automatically deletes entry if feedback is 'down'.
-    """
+    """Record user feedback ('up' or 'down') for a cached answer."""
+
     if _cache_disabled():
         return
 
-    prompt_hash = hashlib.sha256(prompt.encode("utf-8")).hexdigest()
-    _qa_cache.update(
-        ids=[prompt_hash],
-        metadatas=[{"feedback": feedback}]
-    )
+    result = _qa_cache.query(query_texts=[prompt], n_results=1)
+    ids = result.get("ids", [[]])[0]
+    if not ids:
+        return
+
+    cache_id = ids[0]
+    _qa_cache.update(ids=[cache_id], metadatas=[{"feedback": feedback}])
 
     if feedback == "down":
         try:
-            _qa_cache.delete(ids=[prompt_hash])
+            _qa_cache.delete(ids=[cache_id])
         except Exception:
             pass

--- a/app/router.py
+++ b/app/router.py
@@ -13,7 +13,7 @@ from .telemetry import log_record_var
 from .memory import memgpt
 from .memory.vector_store import add_user_memory, cache_answer, lookup_cached_answer
 from .prompt_builder import PromptBuilder
-from .skills.base import check_builtin_skills
+from .skills.base import check_builtin_skills, SKILLS as CATALOG
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- refactor vector store into a semantic cache with prompt-based documents and answer metadata
- add safe collection wrapper and flexible cache API
- expose skills catalog alias for testing

## Testing
- `OPENAI_API_KEY=dummy python -m pytest tests/test_memory_hygiene.py tests/test_semantic_cache.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688e5a7dabc0832a8b03ed6661155b75