### PR TITLE
Add world clock, forecast, conversion, currency, and calendar skills

### DIFF
--- a/app/skills/__init__.py
+++ b/app/skills/__init__.py
@@ -4,7 +4,9 @@ from .base import SKILLS
 
 # core skills
 from .clock_skill import ClockSkill
+from .world_clock_skill import WorldClockSkill
 from .weather_skill import WeatherSkill
+from .forecast_skill import ForecastSkill
 from .reminder_skill import ReminderSkill
 from .lights_skill import LightsSkill
 from .door_lock_skill import DoorLockSkill
@@ -16,6 +18,9 @@ from .notes_skill import NotesSkill
 from .status_skill import StatusSkill
 from .timer_skill import TimerSkill
 from .math_skill import MathSkill
+from .unit_conversion_skill import UnitConversionSkill
+from .currency_skill import CurrencySkill
+from .calendar_skill import CalendarSkill
 from .scene_skill import SceneSkill
 from .script_skill import ScriptSkill
 from .cover_skill import CoverSkill
@@ -33,10 +38,15 @@ from .entities_skill import EntitiesSkill    # “list all lights”
 # ───────────────────────────────────────────
 SKILLS.extend([
     ClockSkill(),
+    WorldClockSkill(),
     WeatherSkill(),
+    ForecastSkill(),
     ReminderSkill(),
     TimerSkill(),
     MathSkill(),
+    UnitConversionSkill(),
+    CurrencySkill(),
+    CalendarSkill(),
 
     TeachSkill(),        # alias learning first for quick matches
     EntitiesSkill(),     # optional helper to dump HA entities
@@ -64,18 +74,17 @@ SKILLS.extend([
 # ───────────────────────────────────────────
 __all__ = [
     "ClockSkill",
+    "WorldClockSkill",
     "WeatherSkill",
+    "ForecastSkill",
     "ReminderSkill",
-    "TeachSkill",
-    "EntitiesSkill",
-    "LightsSkill",
-    "DoorLockSkill",
-    "MusicSkill",
-    "RokuSkill",
-    "ClimateSkill",
-    "VacuumSkill",
     "TimerSkill",
     "MathSkill",
+    "UnitConversionSkill",
+    "CurrencySkill",
+    "CalendarSkill",
+    "TeachSkill",
+    "EntitiesSkill",
     "SceneSkill",
     "ScriptSkill",
     "CoverSkill",
@@ -83,6 +92,12 @@ __all__ = [
     "NotifySkill",
     "SearchSkill",
     "TranslateSkill",
+    "LightsSkill",
+    "DoorLockSkill",
+    "MusicSkill",
+    "RokuSkill",
+    "ClimateSkill",
+    "VacuumSkill",
     "NotesSkill",
     "StatusSkill",
     "SKILLS",

--- a/app/skills/calendar_skill.py
+++ b/app/skills/calendar_skill.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import json
+import os
+import re
+from pathlib import Path
+import datetime as _dt
+
+from .base import Skill
+
+CAL_FILE = Path(os.getenv("CALENDAR_FILE", "data/calendar.json"))
+
+
+class CalendarSkill(Skill):
+    PATTERNS = [
+        re.compile(r"\btoday'?s (?:events|appointments)\b", re.I),
+        re.compile(r"\bupcoming (?:events|appointments)\b", re.I),
+        re.compile(r"\bwhat(?:'s| is)? on my calendar\b", re.I),
+    ]
+
+    async def run(self, prompt: str, match: re.Match) -> str:
+        try:
+            with CAL_FILE.open() as f:
+                events = json.load(f)
+        except Exception:
+            return "No calendar data available."
+
+        today = _dt.date.today().isoformat()
+        if "upcoming" in prompt.lower():
+            items = [e for e in events if e.get("date", "") >= today]
+        else:
+            items = [e for e in events if e.get("date") == today]
+        if not items:
+            return "No events found."
+        parts = []
+        for e in items:
+            time = e.get("time", "")
+            title = e.get("title", "")
+            if time:
+                parts.append(f"{time} {title}")
+            else:
+                parts.append(title)
+        return " | ".join(parts)

--- a/app/skills/currency_skill.py
+++ b/app/skills/currency_skill.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import os
+import re
+import httpx
+import logging
+
+from .base import Skill
+
+log = logging.getLogger(__name__)
+
+# basic currency name to code mapping
+CODES = {
+    "usd": "USD", "dollar": "USD", "dollars": "USD",
+    "eur": "EUR", "euro": "EUR", "euros": "EUR",
+    "jpy": "JPY", "yen": "JPY",
+    "gbp": "GBP", "pound": "GBP", "pounds": "GBP",
+}
+
+
+class CurrencySkill(Skill):
+    PATTERNS = [
+        re.compile(r"how many ([a-zA-Z]+) (?:is|are) (\d+(?:\.\d+)?) ([a-zA-Z]+)", re.I),
+        re.compile(r"(\d+(?:\.\d+)?) ([a-zA-Z]+) to ([a-zA-Z]+)", re.I),
+        re.compile(r"convert (\d+(?:\.\d+)?) ([a-zA-Z]+) to ([a-zA-Z]+)", re.I),
+    ]
+
+    async def run(self, prompt: str, match: re.Match) -> str:
+        groups = match.groups()
+        if len(groups) == 3 and "how many" in match.re.pattern:
+            to_cur, amount, from_cur = groups
+        elif len(groups) == 3 and "convert" in match.re.pattern:
+            amount, from_cur, to_cur = groups
+        else:
+            amount, from_cur, to_cur = groups
+        amount = float(amount)
+        from_code = CODES.get(from_cur.lower(), from_cur.upper())
+        to_code = CODES.get(to_cur.lower(), to_cur.upper())
+        try:
+            async with httpx.AsyncClient(timeout=5) as client:
+                resp = await client.get(
+                    "https://api.exchangerate.host/convert",
+                    params={"from": from_code, "to": to_code, "amount": amount},
+                )
+                resp.raise_for_status()
+                data = resp.json()
+                result = data.get("result")
+                if result is None:
+                    raise ValueError("no result")
+        except Exception:
+            log.exception("Currency conversion failed")
+            return "Currency conversion failed."
+        return f"{amount:.2f} {from_code} is {result:.2f} {to_code}."

--- a/app/skills/forecast_skill.py
+++ b/app/skills/forecast_skill.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import datetime as _dt
+import os
+import re
+from collections import defaultdict
+import httpx
+import logging
+
+from .base import Skill
+
+log = logging.getLogger(__name__)
+
+OPENWEATHER_KEY = os.getenv("OPENWEATHER_API_KEY")
+DEFAULT_CITY = os.getenv("CITY_NAME", "Detroit,US")
+
+
+class ForecastSkill(Skill):
+    PATTERNS = [
+        re.compile(r"\b(?:3|three)[- ]day forecast(?: for ([\w\s]+))?", re.I),
+    ]
+
+    async def run(self, prompt: str, match: re.Match) -> str:
+        city = match.group(1).strip() if match.lastindex == 1 else DEFAULT_CITY
+        if not OPENWEATHER_KEY:
+            return "Weather API key not set."
+        try:
+            async with httpx.AsyncClient(timeout=5) as client:
+                resp = await client.get(
+                    "https://api.openweathermap.org/data/2.5/forecast",
+                    params={
+                        "q": city,
+                        "appid": OPENWEATHER_KEY,
+                        "units": "imperial",
+                    },
+                )
+                resp.raise_for_status()
+                data = resp.json()
+        except Exception:
+            log.exception("Forecast fetch failed")
+            return f"Couldn't get the forecast for {city.title()}."
+
+        temps: dict[str, list[float]] = defaultdict(list)
+        for item in data.get("list", []):
+            date = item.get("dt_txt", "").split(" ")[0]
+            if not date:
+                continue
+            temps[date].append(item.get("main", {}).get("temp"))
+
+        dates = sorted(temps.keys())[:3]
+        parts = []
+        for d in dates:
+            values = [t for t in temps[d] if isinstance(t, (int, float))]
+            if not values:
+                continue
+            day = _dt.datetime.strptime(d, "%Y-%m-%d").strftime("%a")
+            parts.append(f"{day}: {max(values):.0f}/{min(values):.0f}\u00b0F")
+        return " | ".join(parts) if parts else f"No forecast data for {city.title()}."

--- a/app/skills/unit_conversion_skill.py
+++ b/app/skills/unit_conversion_skill.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import re
+from typing import Callable, Dict, Tuple
+
+from .base import Skill
+
+# simple conversion functions
+def _l_to_oz(x: float) -> float: return x * 33.814
+
+def _oz_to_l(x: float) -> float: return x * 0.0295735
+
+def _c_to_f(x: float) -> float: return x * 9 / 5 + 32
+
+def _f_to_c(x: float) -> float: return (x - 32) * 5 / 9
+
+def _km_to_mi(x: float) -> float: return x * 0.621371
+
+def _mi_to_km(x: float) -> float: return x * 1.60934
+
+CONVERSIONS: Dict[Tuple[str, str], Callable[[float], float]] = {
+    ("liter", "ounce"): _l_to_oz,
+    ("ounce", "liter"): _oz_to_l,
+    ("c", "f"): _c_to_f,
+    ("f", "c"): _f_to_c,
+    ("kilometer", "mile"): _km_to_mi,
+    ("mile", "kilometer"): _mi_to_km,
+}
+
+
+class UnitConversionSkill(Skill):
+    PATTERNS = [
+        re.compile(r"how many ([a-zA-Z]+) in (\d+(?:\.\d+)?) ([a-zA-Z]+)", re.I),
+        re.compile(r"(\d+(?:\.\d+)?)\s*°?\s*(c|f)\s*to\s*(c|f)", re.I),
+        re.compile(r"convert (\d+(?:\.\d+)?) ([a-zA-Z]+) to ([a-zA-Z]+)", re.I),
+    ]
+
+    async def run(self, prompt: str, match: re.Match) -> str:
+        groups = match.groups()
+        if len(groups) == 3 and "how many" in match.re.pattern:
+            to_unit, amount, from_unit = groups
+        elif len(groups) == 3 and "convert" in match.re.pattern:
+            amount, from_unit, to_unit = groups
+        elif len(groups) == 3:
+            amount, from_unit, to_unit = groups
+        else:
+            return "Unsupported conversion."
+
+        amount = float(amount)
+        from_unit = from_unit.lower().rstrip('s')
+        to_unit = to_unit.lower().rstrip('s')
+        func = CONVERSIONS.get((from_unit, to_unit))
+        if not func:
+            return "Conversion not supported."
+        result = func(amount)
+        return f"{amount:g} {from_unit}{'' if amount==1 else 's'} is {result:.2f} {to_unit}{'' if result==1 else 's'}."

--- a/app/skills/world_clock_skill.py
+++ b/app/skills/world_clock_skill.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import datetime as _dt
+import re
+from zoneinfo import ZoneInfo
+
+from .base import Skill
+
+# minimal city to timezone mapping
+CITY_TZS = {
+    "tokyo": "Asia/Tokyo",
+    "london": "Europe/London",
+    "new york": "America/New_York",
+    "los angeles": "America/Los_Angeles",
+    "sydney": "Australia/Sydney",
+}
+
+
+class WorldClockSkill(Skill):
+    PATTERNS = [
+        re.compile(r"\bwhat time is it in ([\w\s]+)\??", re.I),
+        re.compile(r"\btime in ([\w\s]+)\b", re.I),
+    ]
+
+    async def run(self, prompt: str, match: re.Match) -> str:
+        city = match.group(1).strip().lower()
+        tz_name = CITY_TZS.get(city)
+        if not tz_name:
+            return f"I don't know the timezone for {city.title()}."
+        now = _dt.datetime.now(ZoneInfo(tz_name)).strftime("%H:%M")
+        return f"It's {now} in {city.title()}."

--- a/tests/test_skills/test_calendar_skill.py
+++ b/tests/test_skills/test_calendar_skill.py
@@ -1,0 +1,29 @@
+import os, sys, asyncio, json, datetime as dt
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+os.environ.setdefault("OLLAMA_URL","http://x")
+os.environ.setdefault("OLLAMA_MODEL","llama3")
+os.environ.setdefault("HOME_ASSISTANT_URL","http://ha")
+os.environ.setdefault("HOME_ASSISTANT_TOKEN","token")
+
+import app.skills.calendar_skill as cal
+
+
+def test_calendar_skill(tmp_path, monkeypatch):
+    today = dt.date.today().isoformat()
+    tomorrow = (dt.date.today() + dt.timedelta(days=1)).isoformat()
+    data = [
+        {"date": today, "time": "09:00", "title": "Breakfast"},
+        {"date": tomorrow, "time": "10:00", "title": "Meeting"},
+    ]
+    f = tmp_path / "calendar.json"
+    f.write_text(json.dumps(data))
+    monkeypatch.setattr(cal, "CAL_FILE", f)
+
+    skill = cal.CalendarSkill()
+    m = skill.match("today's events")
+    assert m
+    resp = asyncio.run(skill.run("today's events", m))
+    assert "Breakfast" in resp
+    m2 = skill.match("upcoming appointments")
+    resp2 = asyncio.run(skill.run("upcoming appointments", m2))
+    assert "Meeting" in resp2

--- a/tests/test_skills/test_currency_skill.py
+++ b/tests/test_skills/test_currency_skill.py
@@ -1,0 +1,34 @@
+import os, sys, asyncio
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+os.environ.setdefault("OLLAMA_URL","http://x")
+os.environ.setdefault("OLLAMA_MODEL","llama3")
+os.environ.setdefault("HOME_ASSISTANT_URL","http://ha")
+os.environ.setdefault("HOME_ASSISTANT_TOKEN","token")
+
+import httpx
+from app.skills.currency_skill import CurrencySkill
+
+
+class FakeClient:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+    async def get(self, url, params=None):
+        class R:
+            def json(self_non):
+                return {"result": 90}
+            def raise_for_status(self_non):
+                pass
+        return R()
+
+
+def test_currency_skill(monkeypatch):
+    monkeypatch.setattr(httpx, "AsyncClient", lambda **kw: FakeClient())
+    skill = CurrencySkill()
+    m = skill.match("100 usd to eur")
+    assert m
+    resp = asyncio.run(skill.run("100 usd to eur", m))
+    assert "90.00 EUR" in resp

--- a/tests/test_skills/test_forecast_skill.py
+++ b/tests/test_skills/test_forecast_skill.py
@@ -1,0 +1,46 @@
+import os, sys, asyncio
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+os.environ.setdefault("OLLAMA_URL","http://x")
+os.environ.setdefault("OLLAMA_MODEL","llama3")
+os.environ.setdefault("HOME_ASSISTANT_URL","http://ha")
+os.environ.setdefault("HOME_ASSISTANT_TOKEN","token")
+os.environ.setdefault("OPENWEATHER_API_KEY","dummy")
+
+import httpx
+from app.skills.forecast_skill import ForecastSkill
+
+
+class FakeClient:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+    async def get(self, url, params=None):
+        class R:
+            def json(self_non):
+                return {
+                    "list": [
+                        {"dt_txt": "2025-01-01 00:00:00", "main": {"temp": 50}},
+                        {"dt_txt": "2025-01-01 03:00:00", "main": {"temp": 60}},
+                        {"dt_txt": "2025-01-02 00:00:00", "main": {"temp": 55}},
+                        {"dt_txt": "2025-01-02 03:00:00", "main": {"temp": 65}},
+                        {"dt_txt": "2025-01-03 00:00:00", "main": {"temp": 70}},
+                        {"dt_txt": "2025-01-03 03:00:00", "main": {"temp": 80}},
+                    ]
+                }
+            def raise_for_status(self_non):
+                pass
+        return R()
+
+
+def test_forecast_skill(monkeypatch):
+    monkeypatch.setattr(httpx, "AsyncClient", lambda **kw: FakeClient())
+    import app.skills.forecast_skill as fs
+    monkeypatch.setattr(fs, "OPENWEATHER_KEY", "dummy")
+    skill = ForecastSkill()
+    m = skill.match("3 day forecast for Paris")
+    assert m
+    resp = asyncio.run(skill.run("3 day forecast for Paris", m))
+    assert "Wed" in resp and resp.count("|") == 2

--- a/tests/test_skills/test_unit_conversion_skill.py
+++ b/tests/test_skills/test_unit_conversion_skill.py
@@ -1,0 +1,19 @@
+import os, sys, asyncio
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+os.environ.setdefault("OLLAMA_URL","http://x")
+os.environ.setdefault("OLLAMA_MODEL","llama3")
+os.environ.setdefault("HOME_ASSISTANT_URL","http://ha")
+os.environ.setdefault("HOME_ASSISTANT_TOKEN","token")
+
+from app.skills.unit_conversion_skill import UnitConversionSkill
+
+
+def test_unit_conversion_skill():
+    skill = UnitConversionSkill()
+    m = skill.match("how many ounces in 2 liters")
+    assert m
+    resp = asyncio.run(skill.run("how many ounces in 2 liters", m))
+    assert "67.63" in resp
+    m2 = skill.match("20 C to F")
+    resp2 = asyncio.run(skill.run("20 C to F", m2))
+    assert "68.00" in resp2

--- a/tests/test_skills/test_world_clock_skill.py
+++ b/tests/test_skills/test_world_clock_skill.py
@@ -1,0 +1,16 @@
+import os, sys, asyncio
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+os.environ.setdefault("OLLAMA_URL","http://x")
+os.environ.setdefault("OLLAMA_MODEL","llama3")
+os.environ.setdefault("HOME_ASSISTANT_URL","http://ha")
+os.environ.setdefault("HOME_ASSISTANT_TOKEN","token")
+
+from app.skills.world_clock_skill import WorldClockSkill
+
+
+def test_world_clock_skill():
+    skill = WorldClockSkill()
+    m = skill.match("what time is it in Tokyo?")
+    assert m
+    resp = asyncio.run(skill.run("what time is it in Tokyo?", m))
+    assert "Tokyo" in resp

--- a/tests/test_skills_init.py
+++ b/tests/test_skills_init.py
@@ -8,10 +8,15 @@ from app import skills
 
 EXPECTED_ORDER = [
     skills.ClockSkill,
+    skills.WorldClockSkill,
     skills.WeatherSkill,
+    skills.ForecastSkill,
     skills.ReminderSkill,
     skills.TimerSkill,
     skills.MathSkill,
+    skills.UnitConversionSkill,
+    skills.CurrencySkill,
+    skills.CalendarSkill,
     skills.TeachSkill,
     skills.EntitiesSkill,
     skills.SceneSkill,


### PR DESCRIPTION
## Summary
- add WorldClockSkill for checking the time in major cities
- provide 3‑day forecasts via ForecastSkill
- support unit conversions, currency conversions, and simple calendar listings

## Testing
- `PYENV_VERSION=3.11.12 python -m pytest tests/test_skills/test_world_clock_skill.py tests/test_skills/test_forecast_skill.py tests/test_skills/test_unit_conversion_skill.py tests/test_skills/test_currency_skill.py tests/test_skills/test_calendar_skill.py tests/test_skills_init.py tests/test_skill_registry.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688e73fbaf2c832abdbd9aa780c352a9