### PR TITLE
feat: inject user prompt into core template

### DIFF
--- a/app/prompt_builder.py
+++ b/app/prompt_builder.py
@@ -52,6 +52,7 @@ class PromptBuilder:
                 "conversation_summary": summary,
                 "memories": mem_text,
                 "custom_instructions": custom_instructions,
+                "user_prompt": user_prompt,
                 "debug_info": dbg,
             }
             for key, val in replacements.items():

--- a/app/prompts/prompt_core.txt
+++ b/app/prompts/prompt_core.txt
@@ -28,4 +28,7 @@ CONVO SNAPSHOT
 {{conversation_summary}}
 
 RELEVANT MEMORY
-{{memories}}_______
+{{memories}}
+
+USER PROMPT
+{{user_prompt}}_______


### PR DESCRIPTION
## Summary
- add `{{user_prompt}}` placeholder to `prompt_core.txt`
- ensure `PromptBuilder.build` substitutes user prompts into template

## Testing
- `PYENV_VERSION=3.11.12 PYTHONPATH=. pytest tests/test_prompt_builder.py`
- `PYENV_VERSION=3.11.12 PYTHONPATH=. python app/prompt_builder.py` (manual check via snippet)


------
https://chatgpt.com/codex/tasks/task_e_688e9a332700832a880dba4199c3c4f2