### PR TITLE
test: expand prompt builder coverage

### DIFF
--- a/tests/test_prompt_builder.py
+++ b/tests/test_prompt_builder.py
@@ -1,3 +1,45 @@
+import sys
+import types
+
+# Provide a minimal chromadb stub so prompt_builder can be imported without the
+# heavy dependency.
+class _DummyCollection:
+    def add(self, *a, **k):
+        pass
+
+    def query(self, *a, **k):
+        return {"documents": [[]], "ids": [[]], "metadatas": [[]]}
+
+    def upsert(self, *a, **k):
+        pass
+
+    def update(self, *a, **k):
+        pass
+
+    def delete(self, *a, **k):
+        pass
+
+
+class _DummyClient:
+    def __init__(self, *a, **k):
+        pass
+
+    def get_or_create_collection(self, *a, **k):
+        return _DummyCollection()
+
+
+chromadb_stub = types.SimpleNamespace(Client=lambda *a, **k: _DummyClient())
+sys.modules.setdefault("chromadb", chromadb_stub)
+class _Settings:
+    def __init__(self, *a, **k):
+        pass
+
+
+sys.modules.setdefault("chromadb.config", types.SimpleNamespace(Settings=_Settings))
+sys.modules.setdefault(
+    "chromadb.utils.embedding_functions", types.SimpleNamespace(EmbeddingFunction=object)
+)
+
 from app import prompt_builder
 from app.prompt_builder import PromptBuilder, MAX_PROMPT_TOKENS
 
@@ -18,3 +60,45 @@ def test_prompt_builder_includes_user_prompt(monkeypatch):
     user_msg = "what is the weather?"
     prompt, _ = PromptBuilder.build(user_msg, session_id="s", user_id="u")
     assert user_msg in prompt
+
+
+def test_prompt_builder_fills_all_fields(monkeypatch):
+    monkeypatch.setattr(
+        prompt_builder.memgpt, "summarize_session", lambda sid: "a summary"
+    )
+    monkeypatch.setattr(
+        prompt_builder,
+        "query_user_memories",
+        lambda uid, q, n_results=5: ["memory1", "memory2"],
+    )
+    prompt, _ = PromptBuilder.build(
+        "question?",
+        session_id="s",
+        user_id="u",
+        custom_instructions="be concise",
+        debug=True,
+        debug_info="DBG",
+    )
+    assert "a summary" in prompt
+    assert "memory1" in prompt and "memory2" in prompt
+    assert "be concise" in prompt
+    assert "DBG" in prompt
+    assert "question?" in prompt
+    assert "{{" not in prompt
+
+
+def test_prompt_builder_drops_summary_before_memories(monkeypatch):
+    monkeypatch.setattr(
+        prompt_builder,
+        "_PROMPT_CORE",
+        "{{conversation_summary}} {{memories}} {{user_prompt}}",
+    )
+    monkeypatch.setattr(prompt_builder, "_count_tokens", lambda text: len(text))
+    monkeypatch.setattr(prompt_builder, "MAX_PROMPT_TOKENS", 50)
+    monkeypatch.setattr(prompt_builder.memgpt, "summarize_session", lambda sid: "S" * 40)
+    monkeypatch.setattr(
+        prompt_builder, "query_user_memories", lambda uid, q, n_results=5: ["M" * 30]
+    )
+    prompt, _ = PromptBuilder.build("hi", session_id="s", user_id="u")
+    assert "S" * 40 not in prompt
+    assert "M" * 30 in prompt


### PR DESCRIPTION
## Summary
- stub chromadb to import PromptBuilder without dependency
- add tests ensuring prompt builder fills all fields and drops summary before memories

## Testing
- `pytest`
- `PYENV_VERSION=3.11.12 PYTHONPATH=$PWD pytest tests/test_prompt_builder.py`


------
https://chatgpt.com/codex/tasks/task_e_688e9e8905a8832a9e6d2ad8fc068ab2