### PR TITLE
feat: add persistent vector store and retriever

### DIFF
--- a/.modelrc
+++ b/.modelrc
@@ -1,0 +1,3 @@
+{
+  "embedding": "text-embedding-3-small"
+}

--- a/app/env_utils.py
+++ b/app/env_utils.py
@@ -1,0 +1,18 @@
+import os
+from pathlib import Path
+from dotenv import load_dotenv
+
+_ENV_PATH = Path('.env')
+_last_mtime = 0.0
+
+def load_env() -> None:
+    """Reload .env into os.environ if the file has changed."""
+    global _last_mtime
+    try:
+        mtime = _ENV_PATH.stat().st_mtime
+    except FileNotFoundError:
+        return
+    if mtime <= _last_mtime:
+        return
+    load_dotenv(override=True)
+    _last_mtime = mtime

--- a/app/main.py
+++ b/app/main.py
@@ -1,6 +1,6 @@
-from dotenv import load_dotenv
+from .env_utils import load_env
 
-load_dotenv()
+load_env()
 import logging
 import uuid
 from pathlib import Path
@@ -112,6 +112,12 @@ async def trace_request(request, call_next):
         log_record_var.reset(token_rec)
         req_id_var.reset(token_req)
     return response
+
+
+@app.middleware("http")
+async def reload_env_middleware(request: Request, call_next):
+    load_env()
+    return await call_next(request)
 
 
 @app.on_event("startup")

--- a/app/memory/vector_store.py
+++ b/app/memory/vector_store.py
@@ -1,26 +1,48 @@
-import uuid
-import time
+from __future__ import annotations
+
 import os
+import time
+import uuid
+from abc import ABC, abstractmethod
+from pathlib import Path
 from typing import List, Optional
 
 import chromadb
 from chromadb.config import Settings
 from chromadb.utils.embedding_functions import EmbeddingFunction
 
-class _LengthEmbeddingFunction(EmbeddingFunction):
-    """Simple embedding based on text length to avoid heavy models."""
-    def __call__(self, texts: List[str]) -> List[List[float]]:
-        return [[float(len(t))] for t in texts]
+from .. import embeddings
 
-# Initialize ChromaDB client and collections
-_client = chromadb.Client(Settings(anonymized_telemetry=False))
-_user_memories = _client.get_or_create_collection(
-    "user_memories",
-    embedding_function=_LengthEmbeddingFunction(),
-)
+
+class VectorStore(ABC):
+    """Abstract VectorStore interface."""
+
+    @abstractmethod
+    def add_user_memory(self, user_id: str, memory: str) -> str: ...
+
+    @abstractmethod
+    def query_user_memories(self, prompt: str, k: int = 5) -> List[str]: ...
+
+    @abstractmethod
+    def cache_answer(self, *args: str) -> None: ...
+
+    @abstractmethod
+    def lookup_cached_answer(self, prompt: str, ttl_seconds: int = 86400) -> Optional[str]: ...
+
+    @abstractmethod
+    def record_feedback(self, prompt: str, feedback: str) -> None: ...
+
+
+class _EmbeddingFunction(EmbeddingFunction):
+    """Embedding function backed by OpenAI's text-embedding-3-small."""
+
+    def __call__(self, texts: List[str]) -> List[List[float]]:  # pragma: no cover - sync wrapper
+        return [embeddings.embed_sync(t) for t in texts]
+
 
 class _SafeCollection:
     """Wrapper around a ChromaDB collection that tolerates empty deletes."""
+
     def __init__(self, col):
         self._col = col
 
@@ -29,98 +51,156 @@ class _SafeCollection:
             return
         return self._col.delete(ids=ids, **kwargs)
 
-    def __getattr__(self, name):
+    def __getattr__(self, name):  # pragma: no cover - simple proxy
         return getattr(self._col, name)
 
-_qa_cache = _SafeCollection(
-    _client.get_or_create_collection(
-        "qa_cache", embedding_function=_LengthEmbeddingFunction()
-    )
-)
 
-def _cache_disabled() -> bool:
-    return bool(os.getenv("DISABLE_QA_CACHE"))
+class ChromaVectorStore(VectorStore):
+    def __init__(self) -> None:
+        settings = Settings(anonymized_telemetry=False)
+        data = Path("data")
+        final = data / "chroma"
+        tmp = data / "chroma_tmp"
+        if final.exists():
+            client = chromadb.PersistentClient(path=str(final), settings=settings)
+        else:
+            tmp.mkdir(parents=True, exist_ok=True)
+            client = chromadb.PersistentClient(path=str(tmp), settings=settings)
+            os.replace(tmp, final)
+            client = chromadb.PersistentClient(path=str(final), settings=settings)
+        self._client = client
+        self._user_memories = self._client.get_or_create_collection(
+            "user_memories", embedding_function=_EmbeddingFunction()
+        )
+        self._qa_cache = _SafeCollection(
+            self._client.get_or_create_collection(
+                "qa_cache", embedding_function=_EmbeddingFunction()
+            )
+        )
 
-def add_user_memory(user_id: str, memory: str) -> str:
-    """Store a memory for a user and return the memory id."""
-    mem_id = str(uuid.uuid4())
-    _user_memories.add(
-        ids=[mem_id],
-        documents=[memory],
-        metadatas=[{"user_id": user_id}],
-    )
-    return mem_id
+    # ─── USER MEMORIES ────────────────────────────────────────────────────────
+    def add_user_memory(self, user_id: str, memory: str) -> str:
+        mem_id = str(uuid.uuid4())
+        self._user_memories.add(
+            ids=[mem_id],
+            documents=[memory],
+            metadatas=[{"user_id": user_id, "ts": time.time()}],
+        )
+        return mem_id
 
-def query_user_memories(user_id: str, query: str, n_results: int = 5) -> List[str]:
-    """Query memories for a user and return matching documents."""
-    results = _user_memories.query(
-        query_texts=[query],
-        where={"user_id": user_id},
-        n_results=n_results
-    )
-    return results.get("documents", [[]])[0]
+    def query_user_memories(self, prompt: str, k: int = 5) -> List[str]:
+        results = self._user_memories.query(
+            query_texts=[prompt], n_results=k, include=["documents", "distances", "metadatas"]
+        )
+        docs = results.get("documents", [[]])[0]
+        dists = results.get("distances", [[]])[0]
+        metas = results.get("metadatas", [[]])[0]
+        items = []
+        for doc, dist, meta in zip(docs, dists, metas):
+            if not doc:
+                continue
+            sim = 1.0 - float(dist)
+            if sim < 0.80:
+                continue
+            ts = float((meta or {}).get("ts", 0))
+            items.append({"doc": doc, "sim": sim, "ts": ts})
+        items.sort(key=lambda x: (-x["sim"], -x["ts"]))
+        return [it["doc"] for it in items[:3]]
 
-def cache_answer(*args: str) -> None:
-    """Store an answer in the semantic cache.
+    # ─── QA CACHE ─────────────────────────────────────────────────────────────
+    def _cache_disabled(self) -> bool:
+        return bool(os.getenv("DISABLE_QA_CACHE"))
 
-    Supports `cache_answer(prompt, answer)` or
-    `cache_answer(cache_id, prompt, answer)`.
-    """
-    if _cache_disabled():
-        return
-    if len(args) == 2:
-        cache_id, prompt, answer = args[0], args[0], args[1]
-    elif len(args) == 3:
-        cache_id, prompt, answer = args
-    else:
-        raise TypeError("cache_answer expects 2 or 3 string arguments")
+    def cache_answer(self, *args: str) -> None:
+        if self._cache_disabled():
+            return
+        if len(args) == 2:
+            cache_id, prompt, answer = args[0], args[0], args[1]
+        elif len(args) == 3:
+            cache_id, prompt, answer = args
+        else:
+            raise TypeError("cache_answer expects 2 or 3 string arguments")
+        self._qa_cache.upsert(
+            ids=[cache_id],
+            documents=[prompt],
+            metadatas=[{"answer": answer, "timestamp": time.time(), "feedback": None}],
+        )
 
-    _qa_cache.upsert(
-        ids=[cache_id],
-        documents=[prompt],
-        metadatas=[{"answer": answer, "timestamp": time.time(), "feedback": None}],
-    )
-
-def lookup_cached_answer(prompt: str, ttl_seconds: int = 86400) -> Optional[str]:
-    """Retrieve a cached answer most similar to `prompt`."""
-    if _cache_disabled():
-        return None
-
-    result = _qa_cache.query(query_texts=[prompt], n_results=1)
-    ids = result.get("ids", [[]])[0]
-    metas = result.get("metadatas", [[]])[0]
-    if not ids or not metas:
-        return None
-
-    cache_id = ids[0]
-    meta = metas[0] or {}
-    answer = meta.get("answer")
-    fb = meta.get("feedback")
-    ts = meta.get("timestamp", 0)
-
-    if fb == "down" or (ts and time.time() - ts > ttl_seconds):
-        try:
-            _qa_cache.delete(ids=[cache_id])
-        finally:
+    def lookup_cached_answer(self, prompt: str, ttl_seconds: int = 86400) -> Optional[str]:
+        if self._cache_disabled():
             return None
+        result = self._qa_cache.query(query_texts=[prompt], n_results=1)
+        ids = result.get("ids", [[]])[0]
+        metas = result.get("metadatas", [[]])[0]
+        if not ids or not metas:
+            return None
+        cache_id = ids[0]
+        meta = metas[0] or {}
+        answer = meta.get("answer")
+        fb = meta.get("feedback")
+        ts = meta.get("timestamp", 0)
+        if fb == "down" or (ts and time.time() - ts > ttl_seconds):
+            try:
+                self._qa_cache.delete(ids=[cache_id])
+            finally:
+                return None
+        return answer
 
-    return answer
+    def record_feedback(self, prompt: str, feedback: str) -> None:
+        if self._cache_disabled():
+            return
+        result = self._qa_cache.query(query_texts=[prompt], n_results=1)
+        ids = result.get("ids", [[]])[0]
+        if not ids:
+            return
+        cache_id = ids[0]
+        self._qa_cache.update(ids=[cache_id], metadatas=[{"feedback": feedback}])
+        if feedback == "down":
+            try:
+                self._qa_cache.delete(ids=[cache_id])
+            except Exception:  # pragma: no cover - best effort
+                pass
 
-def record_feedback(prompt: str, feedback: str) -> None:
-    """Record user feedback ('up' or 'down') for a cached answer."""
-    if _cache_disabled():
-        return
 
-    result = _qa_cache.query(query_texts=[prompt], n_results=1)
-    ids = result.get("ids", [[]])[0]
-    if not ids:
-        return
+class PgVectorStore(VectorStore):  # pragma: no cover - stub implementation
+    def add_user_memory(self, user_id: str, memory: str) -> str:
+        raise NotImplementedError
 
-    cache_id = ids[0]
-    _qa_cache.update(ids=[cache_id], metadatas=[{"feedback": feedback}])
+    def query_user_memories(self, prompt: str, k: int = 5) -> List[str]:
+        return []
 
-    if feedback == "down":
-        try:
-            _qa_cache.delete(ids=[cache_id])
-        except Exception:
-            pass
+    def cache_answer(self, *args: str) -> None:
+        pass
+
+    def lookup_cached_answer(self, prompt: str, ttl_seconds: int = 86400) -> Optional[str]:
+        return None
+
+    def record_feedback(self, prompt: str, feedback: str) -> None:
+        pass
+
+
+def _get_store() -> VectorStore:
+    backend = os.getenv("VECTOR_STORE", "chroma").lower()
+    if backend == "pgvector":
+        return PgVectorStore()
+    return ChromaVectorStore()
+
+
+_store = _get_store()
+
+add_user_memory = _store.add_user_memory
+query_user_memories = _store.query_user_memories
+cache_answer = _store.cache_answer
+lookup_cached_answer = _store.lookup_cached_answer
+record_feedback = _store.record_feedback
+
+__all__ = [
+    "add_user_memory",
+    "query_user_memories",
+    "cache_answer",
+    "lookup_cached_answer",
+    "record_feedback",
+    "VectorStore",
+    "ChromaVectorStore",
+    "PgVectorStore",
+]

--- a/app/prompt_builder.py
+++ b/app/prompt_builder.py
@@ -39,10 +39,24 @@ class PromptBuilder:
         """Return a tuple of (prompt_str, prompt_tokens)."""
         date_time = datetime.utcnow().replace(tzinfo=timezone.utc).isoformat()
         summary = memgpt.summarize_session(session_id) or ""
-        memories: List[str] = query_user_memories(user_id, user_prompt, n_results=top_k)
+        memories: List[str] = query_user_memories(user_prompt, k=top_k)[:3]
+        while _count_tokens("\n".join(memories)) > 55 and memories:
+            memories.pop()
         dbg = debug_info if debug else ""
+        base_prompt = _PROMPT_CORE
+        base_replacements = {
+            "date_time": date_time,
+            "conversation_summary": summary,
+            "memories": "",
+            "custom_instructions": custom_instructions,
+            "user_prompt": user_prompt,
+            "debug_info": dbg,
+        }
+        for key, val in base_replacements.items():
+            base_prompt = base_prompt.replace(f"{{{{{key}}}}}", val)
+        base_tokens = _count_tokens(base_prompt)
 
-        # Token budgeting: remove summary first, then memories oldest-first
+        # Token budgeting: remove summary first, then drop low-sim/oldest
         mem_list = list(memories)
         while True:
             prompt = _PROMPT_CORE
@@ -58,13 +72,21 @@ class PromptBuilder:
             for key, val in replacements.items():
                 prompt = prompt.replace(f"{{{{{key}}}}}", val)
             prompt_tokens = _count_tokens(prompt)
-            if prompt_tokens <= MAX_PROMPT_TOKENS:
+            if (
+                prompt_tokens <= MAX_PROMPT_TOKENS
+                and prompt_tokens - base_tokens <= 75
+            ):
                 break
             if summary:
                 summary = ""
+                base_replacements["conversation_summary"] = ""
+                base_prompt = _PROMPT_CORE
+                for key, val in base_replacements.items():
+                    base_prompt = base_prompt.replace(f"{{{{{key}}}}}", val)
+                base_tokens = _count_tokens(base_prompt)
                 continue
             if mem_list:
-                mem_list.pop(0)
+                mem_list.pop()
                 continue
             break
         return prompt, prompt_tokens

--- a/bench/embed.py
+++ b/bench/embed.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+import asyncio
+import sys
+
+from app import embeddings
+
+TEXT = sys.argv[1] if len(sys.argv) > 1 else "hello world"
+ITERS = int(sys.argv[2]) if len(sys.argv) > 2 else 10
+
+async def main() -> None:
+    metrics = await embeddings.benchmark(TEXT, iterations=ITERS)
+    print(metrics)
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -5,7 +5,7 @@ import asyncio
 
 
 class DummyOpenAIEmbeddings:
-    async def create(self, model: str, input: str):  # pragma: no cover - simple stub
+    def create(self, model: str, input: str):  # pragma: no cover - simple stub
         class Resp:
             data = [type("d", (), {"embedding": [1.0, 2.0, 3.0]})()]
 
@@ -53,4 +53,3 @@ def test_benchmark(monkeypatch):
 
     metrics = asyncio.run(embeddings.benchmark("x", iterations=5))
     assert "latency" in metrics and "throughput" in metrics
-

--- a/tests/test_prompt_builder.py
+++ b/tests/test_prompt_builder.py
@@ -28,7 +28,10 @@ class _DummyClient:
         return _DummyCollection()
 
 
-chromadb_stub = types.SimpleNamespace(Client=lambda *a, **k: _DummyClient())
+chromadb_stub = types.SimpleNamespace(
+    Client=lambda *a, **k: _DummyClient(),
+    PersistentClient=lambda *a, **k: _DummyClient(),
+)
 sys.modules.setdefault("chromadb", chromadb_stub)
 class _Settings:
     def __init__(self, *a, **k):
@@ -47,7 +50,7 @@ from app.prompt_builder import PromptBuilder, MAX_PROMPT_TOKENS
 def test_prompt_builder_respects_token_limit(monkeypatch):
     big = "token " * 12000
     monkeypatch.setattr(prompt_builder.memgpt, "summarize_session", lambda sid: big)
-    monkeypatch.setattr(prompt_builder, "query_user_memories", lambda uid, q, n_results=5: [big, big])
+    monkeypatch.setattr(prompt_builder, "query_user_memories", lambda q, k=5: [big, big])
 
     prompt, tokens = PromptBuilder.build("hi", session_id="s", user_id="u")
     assert tokens <= MAX_PROMPT_TOKENS
@@ -55,7 +58,7 @@ def test_prompt_builder_respects_token_limit(monkeypatch):
 def test_prompt_builder_includes_user_prompt(monkeypatch):
     monkeypatch.setattr(prompt_builder.memgpt, "summarize_session", lambda sid: "")
     monkeypatch.setattr(
-        prompt_builder, "query_user_memories", lambda uid, q, n_results=5: []
+        prompt_builder, "query_user_memories", lambda q, k=5: []
     )
     user_msg = "what is the weather?"
     prompt, _ = PromptBuilder.build(user_msg, session_id="s", user_id="u")
@@ -69,7 +72,7 @@ def test_prompt_builder_fills_all_fields(monkeypatch):
     monkeypatch.setattr(
         prompt_builder,
         "query_user_memories",
-        lambda uid, q, n_results=5: ["memory1", "memory2"],
+        lambda q, k=5: ["memory1", "memory2"],
     )
     prompt, _ = PromptBuilder.build(
         "question?",
@@ -97,7 +100,7 @@ def test_prompt_builder_drops_summary_before_memories(monkeypatch):
     monkeypatch.setattr(prompt_builder, "MAX_PROMPT_TOKENS", 50)
     monkeypatch.setattr(prompt_builder.memgpt, "summarize_session", lambda sid: "S" * 40)
     monkeypatch.setattr(
-        prompt_builder, "query_user_memories", lambda uid, q, n_results=5: ["M" * 30]
+        prompt_builder, "query_user_memories", lambda q, k=5: ["M" * 30]
     )
     prompt, _ = PromptBuilder.build("hi", session_id="s", user_id="u")
     assert "S" * 40 not in prompt

--- a/tests/test_retriever_budget.py
+++ b/tests/test_retriever_budget.py
@@ -1,0 +1,61 @@
+import sys
+import types
+
+# Minimal chromadb stub
+class _DummyCollection:
+    def add(self, *a, **k):
+        pass
+
+    def query(self, *a, **k):
+        return {"documents": [[]], "ids": [[]], "metadatas": [[]]}
+
+    def upsert(self, *a, **k):
+        pass
+
+    def update(self, *a, **k):
+        pass
+
+    def delete(self, *a, **k):
+        pass
+
+
+class _DummyClient:
+    def __init__(self, *a, **k):
+        pass
+
+    def get_or_create_collection(self, *a, **k):
+        return _DummyCollection()
+
+
+chromadb_stub = types.SimpleNamespace(
+    Client=lambda *a, **k: _DummyClient(),
+    PersistentClient=lambda *a, **k: _DummyClient(),
+)
+sys.modules.setdefault("chromadb", chromadb_stub)
+class _Settings:
+    def __init__(self, *a, **k):
+        pass
+
+
+sys.modules.setdefault("chromadb.config", types.SimpleNamespace(Settings=_Settings))
+sys.modules.setdefault(
+    "chromadb.utils.embedding_functions", types.SimpleNamespace(EmbeddingFunction=object)
+)
+
+from app.prompt_builder import PromptBuilder
+from app import prompt_builder
+
+
+def test_retriever_budget(monkeypatch):
+    monkeypatch.setattr(prompt_builder.memgpt, "summarize_session", lambda sid: "")
+    # five memories ~10 tokens each
+    mems = [f"memory {i} " * 5 for i in range(5)]
+    monkeypatch.setattr(prompt_builder, "query_user_memories", lambda q, k=5: mems[:k])
+
+    base_prompt, base_tokens = PromptBuilder.build("hi", top_k=0)
+    prompt, tokens = PromptBuilder.build("hi", top_k=5)
+
+    mem_block = prompt.split("RELEVANT MEMORY", 1)[1].split("USER PROMPT", 1)[0]
+    mem_lines = [l for l in mem_block.strip().splitlines() if l.strip()]
+    assert len(mem_lines) <= 3
+    assert tokens - base_tokens <= 75


### PR DESCRIPTION
## Summary
- add `.modelrc` and bench script
- implement persistent Chroma vector store with OpenAI embeddings
- hot-reload environment and smarter memory retrieval with token budgeting

## Testing
- `PYENV_VERSION=3.11.12 python -m pytest tests/test_prompt_builder.py tests/test_embeddings.py tests/test_retriever_budget.py -q`
- `PYENV_VERSION=3.11.12 python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'aiofiles')*

------
https://chatgpt.com/codex/tasks/task_e_688ea6eaccd4832a9f8eaf47676d20ec