### PR TITLE
Fix QA cache exposure and router keyword routing

### DIFF
--- a/app/router.py
+++ b/app/router.py
@@ -100,8 +100,9 @@ async def route_prompt(prompt: str, model_override: str | None = None) -> Any:
         logger.debug("Cache hit")
         return cached
 
-    # E) Complexity check: skip LLaMA for long prompts (>30 words)
-    if len(prompt.split()) > 30:
+    # E) Complexity check: skip LLaMA for long prompts or certain keywords
+    keywords = {"code", "research", "analyze", "explain"}
+    if len(prompt.split()) > 30 or any(k in prompt.lower() for k in keywords):
         built, _ = PromptBuilder.build(prompt, session_id=session_id, user_id=user_id)
         text, pt, ct, unit_price = await ask_gpt(built, "gpt-4o", SYSTEM_PROMPT)
         if rec:


### PR DESCRIPTION
## Summary
- expose QA cache via property and module alias
- ensure embedding vectors are padded to expected size with a deterministic fallback
- route GPT when prompts are long or contain specific keywords
- ignore distant cache hits using distance threshold

## Testing
- `PYENV_VERSION=3.11.12 python -m pytest tests/test_semantic_cache.py tests/test_router.py::test_complexity_checks tests/test_router.py::test_router_fallback_metrics_updated tests/test_memory_hygiene.py::test_memgpt_dedup_and_maintenance -q`

------
https://chatgpt.com/codex/tasks/task_e_688eb34b240c832a8f45274491b327fa