### PR TITLE
Normalize prompt before caching

### DIFF
--- a/app/router.py
+++ b/app/router.py
@@ -10,7 +10,8 @@ from .gpt_client import ask_gpt, SYSTEM_PROMPT
 from .history import append_history
 from .home_assistant import handle_command
 from .memory.vector_store import add_user_memory, cache_answer, lookup_cached_answer, record_feedback
-from .llama_integration import LLAMA_HEALTHY, OLLAMA_MODEL, ask_llama
+from .llama_integration import OLLAMA_MODEL, ask_llama
+from . import llama_integration
 from .telemetry import log_record_var
 from .memory import memgpt
 from .prompt_builder import PromptBuilder
@@ -34,6 +35,7 @@ async def route_prompt(prompt: str, model_override: str | None = None) -> Any:
     session_id = rec.session_id if rec and rec.session_id else "default"
     user_id = rec.user_id if rec and rec.user_id else "anon"
     logger.debug("route_prompt received: %s", prompt)
+    norm_prompt = prompt.lower().strip()
 
     # A) Model override if using GPT
     if model_override is not None:
@@ -51,7 +53,7 @@ async def route_prompt(prompt: str, model_override: str | None = None) -> Any:
             await record("gpt", fallback=True)
             memgpt.store_interaction(prompt, text, session_id=session_id)
             add_user_memory(user_id, f"Q: {prompt}\nA: {text}")
-            cache_answer(prompt, text)
+            cache_answer(norm_prompt, text)
             return text
         else:
             raise HTTPException(
@@ -90,7 +92,7 @@ async def route_prompt(prompt: str, model_override: str | None = None) -> Any:
         return ha_resp
 
     # D) Semantic cache lookup (TTL + feedback)
-    cached = lookup_cached_answer(prompt)
+    cached = lookup_cached_answer(norm_prompt)
     if cached is not None:
         if rec:
             rec.engine_used = "cache"
@@ -121,7 +123,7 @@ async def route_prompt(prompt: str, model_override: str | None = None) -> Any:
         await record("gpt", source="complex")
         memgpt.store_interaction(prompt, text, session_id=session_id)
         add_user_memory(user_id, f"Q: {prompt}\nA: {text}")
-        cache_answer(prompt, text)
+        cache_answer(norm_prompt, text)
         return text
 
     # F) Build prompt with context
@@ -137,7 +139,7 @@ async def route_prompt(prompt: str, model_override: str | None = None) -> Any:
         rec.prompt_tokens = ptokens
 
     # G) LLaMA first
-    if LLAMA_HEALTHY:
+    if llama_integration.LLAMA_HEALTHY:
         llama_model = (
             model_override
             if (model_override and model_override.lower().startswith("llama"))
@@ -157,7 +159,7 @@ async def route_prompt(prompt: str, model_override: str | None = None) -> Any:
                     prompt, result_text, session_id=session_id
                 )
                 add_user_memory(user_id, f"Q: {prompt}\nA: {result_text}")
-                cache_answer(prompt, result_text)
+                cache_answer(norm_prompt, result_text)
                 logger.debug("LLaMA responded OK")
                 return result_text
 
@@ -175,7 +177,7 @@ async def route_prompt(prompt: str, model_override: str | None = None) -> Any:
     await record("gpt", fallback=True)
     memgpt.store_interaction(prompt, text, session_id=session_id)
     add_user_memory(user_id, f"Q: {prompt}\nA: {text}")
-    cache_answer(prompt, text)
+    cache_answer(norm_prompt, text)
     logger.debug("GPT responded OK with gpt-4o")
     return text
 

--- a/tests/test_semantic_cache.py
+++ b/tests/test_semantic_cache.py
@@ -1,8 +1,10 @@
-import os, asyncio
+import os
+import asyncio
 import pytest
 
 
-def test_semantic_cache_hit(monkeypatch):
+@pytest.fixture
+def setup_cache(monkeypatch):
     os.environ["OLLAMA_URL"] = "http://x"
     os.environ["OLLAMA_MODEL"] = "llama3"
     os.environ["HOME_ASSISTANT_URL"] = "http://ha"
@@ -10,29 +12,39 @@ def test_semantic_cache_hit(monkeypatch):
     from app import router
     from app.memory import vector_store
 
-    # Clear cache
     vector_store.qa_cache.delete(ids=vector_store._qa_cache.get()["ids"])
 
-    # Seed cache with a prompt/answer pair
-    original_prompt = "abcdefgh"  # length 8
-    paraphrase = "ijklmnop"       # same length -> similarity 1.0
-    vector_store.cache_answer("hash1", original_prompt, "cached")
-
-    # Avoid side effects
     async def no_ha(prompt: str):
         return None
     monkeypatch.setattr(router, "handle_command", no_ha)
     monkeypatch.setattr(router, "CATALOG", [])
+
     async def fake_llama(prompt, model=None):
         raise AssertionError("llama should not be called")
+
     async def fake_gpt(prompt, model=None, system=None):
         raise AssertionError("gpt should not be called")
+
     monkeypatch.setattr(router, "ask_llama", fake_llama)
     monkeypatch.setattr(router, "ask_gpt", fake_gpt)
+
     async def dummy(*args, **kwargs):
         return None
+
     monkeypatch.setattr(router, "append_history", dummy)
     monkeypatch.setattr(router, "record", dummy)
+    return router, vector_store
 
-    result = asyncio.run(router.route_prompt(paraphrase))
+
+def test_semantic_cache_hit_case_insensitive(setup_cache):
+    router, vector_store = setup_cache
+    vector_store.cache_answer("Hello World", "cached")
+    result = asyncio.run(router.route_prompt("HELLO world"))
+    assert result == "cached"
+
+
+def test_semantic_cache_hit_whitespace_insensitive(setup_cache):
+    router, vector_store = setup_cache
+    vector_store.cache_answer("Hello World", "cached")
+    result = asyncio.run(router.route_prompt("   hello world   "))
     assert result == "cached"


### PR DESCRIPTION
## Summary
- normalize prompts for consistent cache hashing
- look up and store cached answers using normalized content
- add semantic cache tests covering case and whitespace differences

## Testing
- `PYENV_VERSION=3.11.12 python -m pytest tests/test_semantic_cache.py -q`
- `PYENV_VERSION=3.11.12 OPENAI_API_KEY=dummy python -m pytest -q` *(fails: tests/test_router.py::test_complexity_checks - AssertionError: assert 'llama' == 'ok')*

------
https://chatgpt.com/codex/tasks/task_e_688ecb58bf40832a9b107aaf6bcddb6a