### PR TITLE
feat: add cache invalidation CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,14 @@ curl -X POST localhost:8000/ask -d '{"prompt":"turn off kitchen lights"}'
 * Check logs at `/config` endpoint.
 * Detailed error logs saved locally.
 
+### 🗑️ Invalidate Cached Answers
+
+Remove a stored response from the semantic cache using the CLI:
+
+```bash
+python -m app.vector_store invalidate "your original prompt"
+```
+
 ## Event Log
 
 Each `/ask` request writes a JSON object to `data/history.jsonl` capturing core

--- a/app/memory/vector_store.py
+++ b/app/memory/vector_store.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import hashlib
 import os
 import time
+import unicodedata
 import uuid
 from abc import ABC, abstractmethod
 from pathlib import Path
@@ -207,6 +209,27 @@ class PgVectorStore(VectorStore):  # pragma: no cover - stub implementation
         pass
 
 
+def _normalize(text: str) -> str:
+    """Return a canonical form for hashing prompts."""
+    text = unicodedata.normalize("NFKD", text)
+    replacements = {
+        "’": "'",
+        "‘": "'",
+        "“": '"',
+        "”": '"',
+        "—": "-",
+        "–": "-",
+    }
+    for bad, good in replacements.items():
+        text = text.replace(bad, good)
+    return " ".join(text.split()).lower()
+
+
+def _normalized_hash(prompt: str) -> str:
+    """Return SHA-256 hash of the normalized prompt."""
+    return hashlib.sha256(_normalize(prompt).encode("utf-8")).hexdigest()
+
+
 def _get_store() -> VectorStore:
     backend = os.getenv("VECTOR_STORE", "chroma").lower()
     if backend == "pgvector":
@@ -224,12 +247,24 @@ record_feedback = _store.record_feedback
 qa_cache = _store.qa_cache
 _qa_cache = qa_cache
 
+
+def invalidate_cache(prompt: str) -> None:
+    """Remove a cached answer for ``prompt`` if present."""
+    if bool(os.getenv("DISABLE_QA_CACHE")):
+        return
+    cache_id = _normalized_hash(prompt)
+    try:
+        _qa_cache.delete(ids=[cache_id])
+    except Exception:  # pragma: no cover - best effort
+        pass
+
 __all__ = [
     "add_user_memory",
     "query_user_memories",
     "cache_answer",
     "lookup_cached_answer",
     "record_feedback",
+    "invalidate_cache",
     "VectorStore",
     "ChromaVectorStore",
     "PgVectorStore",

--- a/app/vector_store.py
+++ b/app/vector_store.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import argparse
+
+from .memory.vector_store import invalidate_cache
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser("vector_store")
+    sub = parser.add_subparsers(dest="command")
+
+    p_inv = sub.add_parser("invalidate", help="Remove cached answer for prompt")
+    p_inv.add_argument("prompt", help="Original prompt text")
+
+    args = parser.parse_args(argv)
+    if args.command == "invalidate":
+        invalidate_cache(args.prompt)
+    else:  # pragma: no cover - CLI usage
+        parser.print_help()
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()

--- a/tests/test_vector_store_invalidate.py
+++ b/tests/test_vector_store_invalidate.py
@@ -1,0 +1,16 @@
+from app.memory import vector_store
+
+
+def test_invalidate_cache_clears_entry():
+    # Ensure cache is empty
+    vector_store.qa_cache.delete(ids=vector_store._qa_cache.get()["ids"])
+
+    prompt = "Fancy “quotes”—and dashes"
+    answer = "cached"
+    cache_id = vector_store._normalized_hash(prompt)
+    vector_store.cache_answer(cache_id, prompt, answer)
+    assert vector_store.lookup_cached_answer(prompt) == answer
+
+    # Invalidate using a variant that normalizes to the same text
+    vector_store.invalidate_cache('Fancy "quotes"-and dashes')
+    assert vector_store.lookup_cached_answer(prompt) is None


### PR DESCRIPTION
## Summary
- add normalized hash utilities and invalidate_cache to drop stored responses
- expose `python -m app.vector_store invalidate` CLI and document usage
- regression test for cache invalidation

## Testing
- `PYENV_VERSION=3.11.12 python -m pytest tests/test_vector_store_invalidate.py tests/test_semantic_cache.py` *(tests/test_vector_store_invalidate.py passed, tests/test_semantic_cache.py failed: ModuleNotFoundError: No module named 'aiosqlite')*

------
https://chatgpt.com/codex/tasks/task_e_688ecb5cadf0832aaf6aebc9e1fbc0ba