### PR TITLE
Add fuzzy similarity check to memory

### DIFF
--- a/tests/test_memory_hygiene.py
+++ b/tests/test_memory_hygiene.py
@@ -13,6 +13,16 @@ def test_memgpt_dedup_and_maintenance(tmp_path):
     assert m._data["s"][0]["prompt"] == "summary"
 
 
+def test_memgpt_fuzzy_filter(tmp_path):
+    m = MemGPT(storage_path=tmp_path / "mem.json")
+    base = "The quick brown fox jumps over the lazy dog"
+    m.store_interaction("p", base, session_id="s")
+    m.store_interaction("p", "The quick brown fox jumps over a lazy dog", session_id="s")
+    assert len(m._data["s"]) == 1
+    m.store_interaction("p", "Completely unrelated response", session_id="s")
+    assert len(m._data["s"]) == 2
+
+
 def record_feedback(prompt: str, feedback: str) -> None:
     """Record user feedback ('up' or 'down') for a cached answer."""
     if _cache_disabled():


### PR DESCRIPTION
## Summary
- compute and expose a lightweight Jaro-Winkler similarity helper
- skip storing answers that are fuzzy duplicates of recent ones
- test paraphrased duplicates to validate fuzzy memory filter

## Testing
- `PYENV_VERSION=3.11.12 python -m pytest tests/test_memory_hygiene.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688ecb61b424832a8a266094a2626f14