### PR TITLE
feat: add smalltalk skill

### DIFF
--- a/app/router.py
+++ b/app/router.py
@@ -16,6 +16,7 @@ from .telemetry import log_record_var
 from .memory import memgpt
 from .prompt_builder import PromptBuilder, _count_tokens
 from .skills.base import SKILLS as BUILTIN_CATALOG, check_builtin_skills
+from . import skills  # populate built-in registry (SmalltalkSkill, etc.)
 from .intent_detector import detect_intent
 
 

--- a/app/skills/__init__.py
+++ b/app/skills/__init__.py
@@ -3,6 +3,7 @@
 from .base import SKILLS
 
 # core skills
+from .smalltalk_skill import SmalltalkSkill
 from .clock_skill import ClockSkill
 from .world_clock_skill import WorldClockSkill
 from .weather_skill import WeatherSkill
@@ -41,6 +42,7 @@ from .entities_skill import EntitiesSkill    # “list all lights”
 # Instantiate in desired order
 # ───────────────────────────────────────────
 SKILLS.extend([
+    SmalltalkSkill(),
     ClockSkill(),
     WorldClockSkill(),
     WeatherSkill(),
@@ -81,6 +83,7 @@ SKILLS.extend([
 # Public exports
 # ───────────────────────────────────────────
 __all__ = [
+    "SmalltalkSkill",
     "ClockSkill",
     "WorldClockSkill",
     "WeatherSkill",

--- a/app/skills/smalltalk_skill.py
+++ b/app/skills/smalltalk_skill.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import random
+import re
+from collections import deque
+from datetime import datetime
+from typing import Any, Literal, Optional
+
+from .base import Skill
+
+# Core phrases and tags
+GREETINGS = [
+    "Hey there!",
+    "Yo!",
+    "Hello!",
+    "Hi!",
+    "Howdy!",
+    "Heyo!",
+    "Ahoy!",
+    "What's up?",
+    "Greetings!",
+    "Hiya!",
+    "Salutations!",
+    "Yo yo!",
+    "Hey!",
+    "Good to see ya!",
+    "Welcome!",
+    "Hey friend!",
+    "Hi there!",
+    "Yo, what's good?",
+    "Sup!",
+    "Hola!",
+    "Hey, stranger!",
+    "Look who it is!",
+    "Hey sunshine!",
+    "Howdy partner!",
+    "Well hello!",
+]
+
+PERSONA_TAGS = [
+    "—your code gremlin.",
+    "—the ever-curious bot.",
+    "—on standby and caffeinated.",
+    "—spinning up brilliance.",
+    "—your silent partner in crime.",
+    "—with digital jazz hands.",
+    "—keeping it real.",
+]
+
+FALLBACK = "Hey! I'm here—what's the move?"
+
+# Track used greetings and recent responses to avoid repeats
+_USED_GREETINGS: set[str] = set()
+_RECENT_RESPONSES: deque[str] = deque(maxlen=2)
+
+
+def is_greeting(prompt: str) -> bool:
+    """Return True if the prompt looks like a casual greeting."""
+    p = prompt.strip().lower()
+    p = re.sub(r"[!?.]+$", "", p)
+    roots = {
+        "hi",
+        "hello",
+        "hey",
+        "yo",
+        "sup",
+        "good morning",
+        "good afternoon",
+        "good evening",
+    }
+    return p in roots
+
+
+def time_of_day() -> Literal["morning", "afternoon", "evening"]:
+    now = datetime.now().hour
+    if now < 12:
+        return "morning"
+    if now < 18:
+        return "afternoon"
+    return "evening"
+
+
+def memory_hook(user) -> Optional[str]:
+    """Return a project hook string if available."""
+    return getattr(user, "last_project", None)
+
+
+class SmalltalkSkill(Skill):
+    """Quick canned responses for casual greetings."""
+
+    def name(self) -> str:  # pragma: no cover - trivial
+        return "smalltalk"
+
+    def match(self, prompt: str) -> bool:
+        return is_greeting(prompt)
+
+    async def run(self, prompt: str, match: Any) -> str:
+        # ``match`` is ignored; provided for compatibility with ``Skill``
+        resp = self.handle(prompt, getattr(match, "user", None))
+        if resp is None:
+            raise ValueError("no greeting detected")
+        return resp
+
+    def handle(self, prompt: str, user=None) -> Optional[str]:
+        if not is_greeting(prompt):
+            return None
+
+        greeting = self._pick_greeting()
+        follow = self._follow_up(user)
+        tag = self._maybe_persona_tag()
+
+        parts = [greeting]
+        if tag:
+            parts.append(tag)
+        parts.append(follow or FALLBACK)
+        resp = " ".join(parts)
+
+        # Avoid repeating last couple responses
+        tries = 0
+        while resp in _RECENT_RESPONSES and tries < 5:
+            greeting = self._pick_greeting()
+            tag = self._maybe_persona_tag()
+            follow = self._follow_up(user)
+            parts = [greeting]
+            if tag:
+                parts.append(tag)
+            parts.append(follow or FALLBACK)
+            resp = " ".join(parts)
+            tries += 1
+        _RECENT_RESPONSES.append(resp)
+        return resp
+
+    # Internal helpers -------------------------------------------------
+    def _pick_greeting(self) -> str:
+        choices = [g for g in GREETINGS if g not in _USED_GREETINGS]
+        if not choices:
+            _USED_GREETINGS.clear()
+            choices = GREETINGS[:]
+        greeting = random.choice(choices)
+        _USED_GREETINGS.add(greeting)
+        return greeting
+
+    def _maybe_persona_tag(self) -> Optional[str]:
+        if PERSONA_TAGS and random.random() < 0.3:
+            return random.choice(PERSONA_TAGS)
+        return None
+
+    def _follow_up(self, user) -> str:
+        tod = time_of_day()
+        follow = {
+            "morning": "Ready to crush the day?",
+            "afternoon": "How’s your grind going?",
+            "evening": "Late-night hustle or winding down?",
+        }.get(tod, FALLBACK)
+        mem = memory_hook(user)
+        if mem:
+            follow = f"How’s {mem} coming along?"
+        return follow

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -34,7 +34,7 @@ def test_router_fallback_metrics_updated(monkeypatch):
         "transcribe_errors": 0,
     }
 
-    result = asyncio.run(router.route_prompt("hello"))
+    result = asyncio.run(router.route_prompt("hello world"))
     assert result == "ok"
     m = analytics.get_metrics()
     assert m["total"] == 1
@@ -56,7 +56,7 @@ def test_gpt_override(monkeypatch):
 
     monkeypatch.setattr(router, "ask_gpt", fake_gpt)
     monkeypatch.setattr(router, "ALLOWED_GPT_MODELS", {"gpt-4"})
-    result = asyncio.run(router.route_prompt("hi", "gpt-4"))
+    result = asyncio.run(router.route_prompt("hello world", "gpt-4"))
     assert result == "gpt-4"
 
 
@@ -71,7 +71,7 @@ def test_gpt_override_invalid(monkeypatch):
 
     monkeypatch.setattr(router, "ALLOWED_GPT_MODELS", {"gpt-4"})
     with pytest.raises(HTTPException):
-        asyncio.run(router.route_prompt("hi", "gpt-3"))
+        asyncio.run(router.route_prompt("hello world", "gpt-3"))
 
 
 def test_complexity_checks(monkeypatch):
@@ -161,8 +161,8 @@ def test_debug_env_toggle(monkeypatch):
     monkeypatch.setattr(router.PromptBuilder, "build", staticmethod(fake_build))
 
     monkeypatch.setenv("DEBUG", "0")
-    asyncio.run(router.route_prompt("hi"))
+    asyncio.run(router.route_prompt("hello world"))
     monkeypatch.setenv("DEBUG", "1")
-    asyncio.run(router.route_prompt("hi"))
+    asyncio.run(router.route_prompt("hello world"))
 
     assert flags == [False, True]

--- a/tests/test_skills_init.py
+++ b/tests/test_skills_init.py
@@ -7,6 +7,7 @@ os.environ.setdefault("OLLAMA_MODEL", "llama3")
 from app import skills
 
 EXPECTED_ORDER = [
+    skills.SmalltalkSkill,
     skills.ClockSkill,
     skills.WorldClockSkill,
     skills.WeatherSkill,

--- a/tests/test_smalltalk.py
+++ b/tests/test_smalltalk.py
@@ -1,0 +1,35 @@
+import os, sys
+import asyncio
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+os.environ.setdefault('HOME_ASSISTANT_URL', 'http://ha')
+os.environ.setdefault('HOME_ASSISTANT_TOKEN', 'token')
+os.environ.setdefault('OLLAMA_URL', 'http://x')
+os.environ.setdefault('OLLAMA_MODEL', 'llama3')
+
+from app.skills.smalltalk_skill import GREETINGS, SmalltalkSkill, is_greeting
+from app import router, skills
+
+
+def test_is_greeting():
+    assert is_greeting('hi')
+    assert is_greeting('yo!')
+    assert is_greeting('HELLO?')
+    assert not is_greeting("what's new")
+
+
+def test_handle_returns_valid_format():
+    s = SmalltalkSkill()
+
+    class User:
+        last_project = 'garage build'
+
+    resp = s.handle('hello', User())
+    assert resp is not None
+    assert any(resp.startswith(g) for g in GREETINGS)
+    assert resp.endswith('?')
+
+
+def test_router_integration():
+    result = asyncio.run(router.route_prompt('hello'))
+    assert any(result.startswith(g) for g in GREETINGS)


### PR DESCRIPTION
## Summary
- add conversational SmalltalkSkill with varied greetings, persona tags, and context-aware follow-ups
- register SmalltalkSkill in skill registry and router
- expand test suite for greeting detection and router integration

## Testing
- `python3 -m pytest tests/test_smalltalk.py tests/test_skills_init.py`
- `python3 -m pytest tests/test_router.py`


------
https://chatgpt.com/codex/tasks/task_e_688f96f25874832ab5c7497ffe3f864e