### PR TITLE
refactor: improve smalltalk skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,3 +116,8 @@ Welcome to the cast of GesahniV2—your personal AI ensemble that handles everyt
 - **Location:** `app/skills/`
 - **Ordering:** Skills are checked in order defined in
   `app/skills/__init__.py`. The first matching skill responds.
+
+#### Smalltalk Skill
+
+- Persona tag rate is configurable via `SMALLTALK_PERSONA_RATE`.
+- Run `pytest tests/test_smalltalk.py` to validate greeting logic.

--- a/tests/test_smalltalk.py
+++ b/tests/test_smalltalk.py
@@ -1,11 +1,13 @@
 import os, sys
 import asyncio
+from datetime import datetime
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 os.environ.setdefault('HOME_ASSISTANT_URL', 'http://ha')
 os.environ.setdefault('HOME_ASSISTANT_TOKEN', 'token')
 os.environ.setdefault('OLLAMA_URL', 'http://x')
 os.environ.setdefault('OLLAMA_MODEL', 'llama3')
+os.environ.setdefault('SMALLTALK_PERSONA_RATE', '0')
 
 from app.skills.smalltalk_skill import GREETINGS, SmalltalkSkill, is_greeting
 from app import router, skills
@@ -33,3 +35,25 @@ def test_handle_returns_valid_format():
 def test_router_integration():
     result = asyncio.run(router.route_prompt('hello'))
     assert any(result.startswith(g) for g in GREETINGS)
+
+
+def test_no_repeat_logic():
+    s = SmalltalkSkill(persona_rate=0)
+    resps = {s.handle('hi') for _ in range(3)}
+    assert len(resps) >= 2
+
+
+def test_time_provider_injection():
+    morning = SmalltalkSkill(time_provider=lambda: datetime(2024, 1, 1, 8), persona_rate=0)
+    resp = morning.handle('hi')
+    assert 'Ready to crush the day?' in resp
+
+
+def test_memory_hook_formatting():
+    s = SmalltalkSkill(persona_rate=0)
+
+    class User:
+        last_project = 'garage build'
+
+    resp = s.handle('hello', User())
+    assert '`Garage build`' in resp


### PR DESCRIPTION
## Summary
- make SmalltalkSkill stateful per instance and configurable
- add time provider and persona tag rate settings
- expand smalltalk tests and docs

## Testing
- `PYENV_VERSION=3.11.12 pytest tests/test_smalltalk.py`
- `PYENV_VERSION=3.11.12 pytest tests/test_skills_init.py`


------
https://chatgpt.com/codex/tasks/task_e_688f9c126b60832a83ee3c7b343f0d16