### PR TITLE
feat: support user-scoped memory

### DIFF
--- a/app/deps/user.py
+++ b/app/deps/user.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from fastapi import Request, WebSocket
+
+from ..telemetry import log_record_var
+
+
+def get_current_user_id(request: Request | WebSocket | None = None) -> str:
+    """Return the current user's identifier.
+
+    The ID is pulled from ``log_record_var`` which is populated by the request
+    tracing middleware.  When called outside of a request context, ``"local"``
+    is returned.  If a ``Request`` or ``WebSocket`` is provided the resolved
+    ``user_id`` is also attached to ``request.state`` for easy downstream
+    access.
+    """
+
+    rec = log_record_var.get()
+    user_id = rec.user_id if rec and rec.user_id else "local"
+    if request is not None:
+        request.state.user_id = user_id
+    return user_id
+
+__all__ = ["get_current_user_id"]

--- a/app/embeddings.py
+++ b/app/embeddings.py
@@ -113,8 +113,13 @@ def embed_sync(text: str) -> List[float]:
     return _embed_openai_sync(text, bucket)
 
 
-async def benchmark(text: str, iterations: int = 10) -> Dict[str, float]:
-    """Run ``embed`` ``iterations`` times and log latency and throughput."""
+async def benchmark(
+    text: str, iterations: int = 10, user_id: str | None = None
+) -> Dict[str, float]:
+    """Run ``embed`` ``iterations`` times and log latency and throughput.
+
+    ``user_id`` is accepted for interface parity but is not used.
+    """
 
     start = time.perf_counter()
     for _ in range(iterations):

--- a/app/memory/memgpt.py
+++ b/app/memory/memgpt.py
@@ -116,7 +116,15 @@ class MemGPT:
     # ------------------------------------------------------------------
     # Public API
     # ------------------------------------------------------------------
-    def store_interaction(self, prompt: str, answer: str, session_id: str, tags: List[str] | None = None) -> None:
+    def store_interaction(
+        self,
+        prompt: str,
+        answer: str,
+        session_id: str,
+        *,
+        user_id: str | None = None,
+        tags: List[str] | None = None,
+    ) -> None:
         """Persist a prompt/answer pair for ``session_id``.
 
         ``tags`` may include "pin" to force-pin an interaction.
@@ -153,7 +161,7 @@ class MemGPT:
             self._save()
 
 
-    def summarize_session(self, session_id: str) -> str:
+    def summarize_session(self, session_id: str, user_id: str | None = None) -> str:
         """Return a condensed representation of a session's interactions."""
 
         with self._lock:

--- a/app/prompt_builder.py
+++ b/app/prompt_builder.py
@@ -44,8 +44,8 @@ class PromptBuilder:
     ) -> Tuple[str, int]:
         """Return a tuple of (prompt_str, prompt_tokens)."""
         date_time = datetime.utcnow().replace(tzinfo=timezone.utc).isoformat()
-        summary = memgpt.summarize_session(session_id) or ""
-        memories: List[str] = query_user_memories(user_prompt, k=top_k)[:3]
+        summary = memgpt.summarize_session(session_id, user_id=user_id) or ""
+        memories: List[str] = query_user_memories(user_id, user_prompt, k=top_k)[:3]
         rec = log_record_var.get()
         if rec:
             rec.embed_tokens = _count_tokens(user_prompt)

--- a/bench/embed.py
+++ b/bench/embed.py
@@ -3,12 +3,14 @@ import asyncio
 import sys
 
 from app import embeddings
+from app.deps.user import get_current_user_id
 
 TEXT = sys.argv[1] if len(sys.argv) > 1 else "hello world"
 ITERS = int(sys.argv[2]) if len(sys.argv) > 2 else 10
 
 async def main() -> None:
-    metrics = await embeddings.benchmark(TEXT, iterations=ITERS)
+    user_id = get_current_user_id()
+    metrics = await embeddings.benchmark(TEXT, iterations=ITERS, user_id=user_id)
     print(metrics)
 
 if __name__ == "__main__":

--- a/tests/test_llama_health.py
+++ b/tests/test_llama_health.py
@@ -71,7 +71,7 @@ def test_router_skips_when_unhealthy(monkeypatch):
         "transcribe_errors": 0,
     }
 
-    result = asyncio.run(router.route_prompt("hello"))
+    result = asyncio.run(router.route_prompt("hello", user_id="u"))
     assert result == "ok"
     m = analytics.get_metrics()
     assert m["total"] == 1

--- a/tests/test_memory_env.py
+++ b/tests/test_memory_env.py
@@ -14,8 +14,8 @@ def test_memory_env_reload(monkeypatch):
     monkeypatch.setattr(store, "_user_memories", fake_collection)
     monkeypatch.setenv("SIM_THRESHOLD", "0")
     monkeypatch.setenv("MEM_TOP_K", "1")
-    assert store.query_user_memories("x") == ["A"]
+    assert store.query_user_memories("u", "x") == ["A"]
     monkeypatch.setenv("MEM_TOP_K", "2")
-    assert store.query_user_memories("x") == ["A", "B"]
+    assert store.query_user_memories("u", "x") == ["A", "B"]
     monkeypatch.setenv("SIM_THRESHOLD", "0.95")
-    assert store.query_user_memories("x") == []
+    assert store.query_user_memories("u", "x") == []

--- a/tests/test_metrics_endpoint.py
+++ b/tests/test_metrics_endpoint.py
@@ -15,7 +15,7 @@ def test_metrics_endpoint(monkeypatch):
     monkeypatch.setattr(home_assistant, "startup_check", lambda: None)
     monkeypatch.setattr(llama_integration, "startup_check", lambda: None)
 
-    async def fake_route(prompt, model=None):
+    async def fake_route(prompt, model=None, user_id="u"):
         rec = log_record_var.get()
         if rec:
             rec.engine_used = "gpt"

--- a/tests/test_retriever_budget.py
+++ b/tests/test_retriever_budget.py
@@ -47,10 +47,14 @@ from app import prompt_builder
 
 
 def test_retriever_budget(monkeypatch):
-    monkeypatch.setattr(prompt_builder.memgpt, "summarize_session", lambda sid: "")
+    monkeypatch.setattr(
+        prompt_builder.memgpt, "summarize_session", lambda sid, user_id=None: ""
+    )
     # five memories ~10 tokens each
     mems = [f"memory {i} " * 5 for i in range(5)]
-    monkeypatch.setattr(prompt_builder, "query_user_memories", lambda q, k=5: mems[:k])
+    monkeypatch.setattr(
+        prompt_builder, "query_user_memories", lambda uid, q, k=5: mems[:k]
+    )
 
     base_prompt, base_tokens = PromptBuilder.build("hi", top_k=0)
     prompt, tokens = PromptBuilder.build("hi", top_k=5)

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -34,7 +34,7 @@ def test_router_fallback_metrics_updated(monkeypatch):
         "transcribe_errors": 0,
     }
 
-    result = asyncio.run(router.route_prompt("hello world"))
+    result = asyncio.run(router.route_prompt("hello world", user_id="u"))
     assert result == "ok"
     m = analytics.get_metrics()
     assert m["total"] == 1
@@ -56,7 +56,7 @@ def test_gpt_override(monkeypatch):
 
     monkeypatch.setattr(router, "ask_gpt", fake_gpt)
     monkeypatch.setattr(router, "ALLOWED_GPT_MODELS", {"gpt-4"})
-    result = asyncio.run(router.route_prompt("hello world", "gpt-4"))
+    result = asyncio.run(router.route_prompt("hello world", "gpt-4", user_id="u"))
     assert result == "gpt-4"
 
 
@@ -71,7 +71,7 @@ def test_gpt_override_invalid(monkeypatch):
 
     monkeypatch.setattr(router, "ALLOWED_GPT_MODELS", {"gpt-4"})
     with pytest.raises(HTTPException):
-        asyncio.run(router.route_prompt("hello world", "gpt-3"))
+        asyncio.run(router.route_prompt("hello world", "gpt-3", user_id="u"))
 
 
 def test_complexity_checks(monkeypatch):
@@ -93,10 +93,10 @@ def test_complexity_checks(monkeypatch):
     monkeypatch.setattr(router, "ask_llama", fake_llama)
 
     long_prompt = "word " * 31
-    assert asyncio.run(router.route_prompt(long_prompt)) == "ok"
+    assert asyncio.run(router.route_prompt(long_prompt, user_id="u")) == "ok"
 
     kw_prompt = "please analyze this"
-    assert asyncio.run(router.route_prompt(kw_prompt)) == "ok"
+    assert asyncio.run(router.route_prompt(kw_prompt, user_id="u")) == "ok"
 
 
 def test_skill_metrics(monkeypatch):
@@ -123,7 +123,7 @@ def test_skill_metrics(monkeypatch):
         "transcribe_count": 0,
         "transcribe_errors": 0,
     }
-    result = asyncio.run(router.route_prompt("dummy task"))
+    result = asyncio.run(router.route_prompt("dummy task", user_id="u"))
     assert result == "done"
     m = analytics.get_metrics()
     assert m["total"] == 1
@@ -161,8 +161,8 @@ def test_debug_env_toggle(monkeypatch):
     monkeypatch.setattr(router.PromptBuilder, "build", staticmethod(fake_build))
 
     monkeypatch.setenv("DEBUG", "0")
-    asyncio.run(router.route_prompt("hello world"))
+    asyncio.run(router.route_prompt("hello world", user_id="u"))
     monkeypatch.setenv("DEBUG", "1")
-    asyncio.run(router.route_prompt("hello world"))
+    asyncio.run(router.route_prompt("hello world", user_id="u"))
 
     assert flags == [False, True]

--- a/tests/test_semantic_cache.py
+++ b/tests/test_semantic_cache.py
@@ -54,14 +54,14 @@ def setup_cache(monkeypatch):
 def test_semantic_cache_hit_case_insensitive(setup_cache):
     router, vector_store = setup_cache
     vector_store.cache_answer("Hello World", "cached")
-    result = asyncio.run(router.route_prompt("HELLO world"))
+    result = asyncio.run(router.route_prompt("HELLO world", user_id="u"))
     assert result == "cached"
 
 
 def test_semantic_cache_hit_whitespace_insensitive(setup_cache):
     router, vector_store = setup_cache
     vector_store.cache_answer("Hello World", "cached")
-    result = asyncio.run(router.route_prompt("   hello world   "))
+    result = asyncio.run(router.route_prompt("   hello world   ", user_id="u"))
     assert result == "cached"
 
 

--- a/tests/test_smalltalk.py
+++ b/tests/test_smalltalk.py
@@ -33,7 +33,7 @@ def test_handle_returns_valid_format():
 
 
 def test_router_integration():
-    result = asyncio.run(router.route_prompt("hello"))
+    result = asyncio.run(router.route_prompt("hello", user_id="u"))
     assert any(result.startswith(g) for g in GREETINGS)
 
 

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -13,7 +13,7 @@ def setup_app(monkeypatch, hist_path):
     monkeypatch.setattr(main, "ha_startup", lambda: None)
     monkeypatch.setattr(main, "llama_startup", lambda: None)
     monkeypatch.setattr("app.history.HISTORY_FILE", hist_path)
-    async def fake_route(prompt: str, model=None):
+    async def fake_route(prompt: str, model=None, user_id: str = "u"):
         from app.prompt_builder import PromptBuilder
         from app.telemetry import log_record_var
         PromptBuilder.build(prompt, session_id="s", user_id="u")
@@ -30,9 +30,11 @@ def test_telemetry_logged(monkeypatch, tmp_path):
     client = setup_app(monkeypatch, str(hist))
     from app import prompt_builder, analytics
     analytics._latency_samples = []
-    monkeypatch.setattr(prompt_builder.memgpt, "summarize_session", lambda sid: "")
     monkeypatch.setattr(
-        prompt_builder, "query_user_memories", lambda q, k=5: ["m1", "m2"]
+        prompt_builder.memgpt, "summarize_session", lambda sid, user_id=None: ""
+    )
+    monkeypatch.setattr(
+        prompt_builder, "query_user_memories", lambda uid, q, k=5: ["m1", "m2"]
     )
     resp = client.post("/ask", json={"prompt": "hi"})
     assert resp.status_code == 200


### PR DESCRIPTION
### Problem
User-specific context was not consistently applied across the API and helpers.

### Solution
- Add `get_current_user_id` helper.
- Require user ID in `route_prompt` and vector store utilities.
- Wire dependency into main endpoints and bench script.
- Adjust prompt builder and tests for new signatures.

### Tests
`PYENV_VERSION=3.11.12 pytest tests/test_prompt_builder.py tests/test_router.py tests/test_memory_env.py -q`
`PYENV_VERSION=3.11.12 ruff check .` *(fails: E402, E401, F401, etc.)*
`PYENV_VERSION=3.11.12 black --check .` *(fails: would reformat many files)*

### Risk
Low. Changes are additive and scoped to user ID plumbing; existing behaviours remain untouched.

------
https://chatgpt.com/codex/tasks/task_e_6890fb060010832ab16842fe87f20fc5