### PR TITLE
feat: track user in transcription

### DIFF
--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,5 +1,5 @@
-import os
 from app import tasks
+
 
 def test_enqueue_fallback(monkeypatch):
     called = []
@@ -8,9 +8,16 @@ def test_enqueue_fallback(monkeypatch):
         raise RuntimeError("no redis")
 
     monkeypatch.setattr(tasks, "_get_queue", raise_err)
-    monkeypatch.setattr(tasks, "transcribe_task", lambda sid: called.append(("t", sid)))
-    tasks.enqueue_transcription("abc")
-    assert called == [("t", "abc")]
+    monkeypatch.setattr(tasks, "_load_meta", lambda sid: {"user_id": "m"})
+    monkeypatch.setattr(
+        tasks, "transcribe_task", lambda sid, uid: called.append(("t", sid, uid))
+    )
+    tasks.enqueue_transcription("abc", "u")
+    assert called == [("t", "abc", "u")]
+
+    called.clear()
+    tasks.enqueue_transcription("def")
+    assert called == [("t", "def", "m")]
 
     called.clear()
     monkeypatch.setattr(tasks, "tag_task", lambda sid: called.append(("g", sid)))


### PR DESCRIPTION
### Problem
Transcription jobs always stored memories as `"anon"`, losing the original session user id.

### Solution
- allow `enqueue_transcription` and `transcribe_task` to receive a `user_id`
- fetch `user_id` from session metadata when not explicitly provided
- pass the current session’s `user_id` when triggering transcription
- update tests accordingly

### Tests
- `PYENV_VERSION=3.11.12 ruff check app/tasks.py app/main.py tests/test_tasks.py`
- `PYENV_VERSION=3.11.12 black --check app/tasks.py app/main.py tests/test_tasks.py`
- `PYENV_VERSION=3.11.12 pytest -q` *(fails: No module named 'fastapi', 'pydantic', 'numpy', 'openai')*

### Risk
Low; function signatures changed to accept `user_id`, requiring call sites to pass the value.

------
https://chatgpt.com/codex/tasks/task_e_689105e34590832aa4a46151c79cb533