### PR TITLE
Handle division by zero in math skill

### DIFF
--- a/app/skills/math_skill.py
+++ b/app/skills/math_skill.py
@@ -1,13 +1,17 @@
 from __future__ import annotations
 import re
-from typing import Optional
 from .base import Skill
+
 
 class MathSkill(Skill):
     PATTERNS = [
-        re.compile(r"(?P<a>\d+(?:\.\d+)?)\s*(?P<op>[+\-*/x×])\s*(?P<b>\d+(?:\.\d+)?)", re.I),
+        re.compile(
+            r"(?P<a>\d+(?:\.\d+)?)\s*(?P<op>[+\-*/x×])\s*(?P<b>\d+(?:\.\d+)?)", re.I
+        ),
         re.compile(r"(?P<pct>\d+(?:\.\d+)?)%\s*of\s*(?P<of>\d+(?:\.\d+)?)", re.I),
-        re.compile(r"round\s+(?P<val>\d+(?:\.\d+)?)\s+to\s+(?P<places>\d+)\s+decimal", re.I),
+        re.compile(
+            r"round\s+(?P<val>\d+(?:\.\d+)?)\s+to\s+(?P<places>\d+)\s+decimal", re.I
+        ),
     ]
 
     async def run(self, prompt: str, match: re.Match) -> str:
@@ -19,6 +23,8 @@ class MathSkill(Skill):
             if op in {"x", "×", "*"}:
                 res = a * b
             elif op == "/":
+                if b == 0:
+                    return "Cannot divide by zero"
                 res = a / b
             elif op == "+":
                 res = a + b

--- a/tests/test_skills/test_math_skill.py
+++ b/tests/test_skills/test_math_skill.py
@@ -1,4 +1,7 @@
-import os, sys, asyncio
+import asyncio
+import os
+import sys
+
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
 
 from app.skills.math_skill import MathSkill
@@ -16,3 +19,10 @@ def test_percentage():
     m = skill.match("25% of 200")
     out = asyncio.run(skill.run("25% of 200", m))
     assert out == "50.0"
+
+
+def test_divide_by_zero():
+    skill = MathSkill()
+    m = skill.match("5 / 0")
+    out = asyncio.run(skill.run("5 / 0", m))
+    assert out == "Cannot divide by zero"


### PR DESCRIPTION
### Problem
MathSkill attempted to divide numbers without checking for zero divisors, resulting in crashes or undefined behavior.

### Solution
Added a guard in the division branch to return a clear message when attempting to divide by zero and extended the test suite to cover this scenario.

### Tests
`pytest -q` *(fails: 55 errors during collection)*
`ruff check .` *(fails: 127 errors)*
`black --check .` *(fails: would reformat 101 files)*

### Risk
Low – change is confined to math skill division handling and associated tests.

------
https://chatgpt.com/codex/tasks/task_e_68910788e62c832a9cca2e6cc4b1c2ff