### PR TITLE
Ensure engine metrics always increment

### DIFF
--- a/app/analytics.py
+++ b/app/analytics.py
@@ -21,11 +21,10 @@ _MAX_SAMPLES = 200
 async def record(engine: str, fallback: bool = False, source: str = "gpt") -> None:
     async with _lock:
         _metrics["total"] += 1
-        if source == "gpt":
-            if engine == "llama":
-                _metrics["llama"] += 1
-            elif engine == "gpt":
-                _metrics["gpt"] += 1
+        if engine == "llama":
+            _metrics["llama"] += 1
+        elif engine == "gpt":
+            _metrics["gpt"] += 1
         if fallback:
             _metrics["fallback"] += 1
 


### PR DESCRIPTION
### Problem
Engine-specific counters in `analytics.record` only incremented when the source was `gpt`, so requests from other sources didn't update these metrics.

### Solution
Removed the source guard so both LLaMA and GPT counters increment for every recorded request.

### Tests
`ruff check .` *(fails: E402 and other style violations across project)*
`black --check .` *(fails: many files would be reformatted)*
`pytest -q` *(fails: missing dependencies such as fastapi and pydantic)*

### Risk
Low—changes are isolated to metric bookkeeping.

------
https://chatgpt.com/codex/tasks/task_e_689107851254832a9eaeff1153b42659