### PR TITLE
Handle anonymous user IDs for WebSocket

### DIFF
--- a/app/deps/user.py
+++ b/app/deps/user.py
@@ -1,24 +1,41 @@
 from __future__ import annotations
 
+from uuid import uuid4
+
 from fastapi import Request, WebSocket
 
-from ..telemetry import log_record_var
+from ..telemetry import LogRecord, log_record_var
 
 
-def get_current_user_id(request: Request | WebSocket | None = None) -> str:
+def get_current_user_id(request: Request) -> str:
     """Return the current user's identifier.
 
     The ID is pulled from ``log_record_var`` which is populated by the request
-    tracing middleware.  When called outside of a request context, ``"local"``
-    is returned.  If a ``Request`` or ``WebSocket`` is provided the resolved
+    tracing middleware. When called outside of a request context, ``"local"`` is
+    returned. If a ``Request`` or ``WebSocket`` is provided the resolved
     ``user_id`` is also attached to ``request.state`` for easy downstream
     access.
     """
 
     rec = log_record_var.get()
-    user_id = rec.user_id if rec and rec.user_id else "local"
-    if request is not None:
-        request.state.user_id = user_id
+    if rec is None:
+        rec = LogRecord(req_id=uuid4().hex)
+        log_record_var.set(rec)
+
+    user_id = rec.user_id
+
+    if not user_id and isinstance(request, WebSocket):
+        from ..main import _anon_user_id
+
+        user_id = _anon_user_id(request.headers.get("Authorization"))
+        rec.user_id = user_id
+
+    if not user_id:
+        user_id = "local"
+
+    request.state.user_id = user_id
+
     return user_id
+
 
 __all__ = ["get_current_user_id"]

--- a/app/main.py
+++ b/app/main.py
@@ -287,7 +287,8 @@ async def trigger_summary_endpoint(
 
 
 @app.websocket("/transcribe")
-async def websocket_transcribe(ws: WebSocket, user_id: str = Depends(get_current_user_id)):
+async def websocket_transcribe(ws: WebSocket) -> None:
+    user_id = get_current_user_id(ws)
     await verify_ws(ws)
     await rate_limit_ws(ws)
     await ws.accept()
@@ -401,7 +402,9 @@ async def start_transcription(
 
 
 @app.get("/transcribe/{session_id}")
-async def get_transcription(session_id: str, user_id: str = Depends(get_current_user_id)):
+async def get_transcription(
+    session_id: str, user_id: str = Depends(get_current_user_id)
+):
     transcript_path = Path(SESSIONS_DIR) / session_id / "transcript.txt"
     if transcript_path.exists():
         return {"text": transcript_path.read_text(encoding="utf-8")}

--- a/tests/test_ws_user_id.py
+++ b/tests/test_ws_user_id.py
@@ -1,0 +1,49 @@
+import os
+from fastapi.testclient import TestClient
+
+
+def setup_app(monkeypatch, tmp_path):
+    os.environ.setdefault("OLLAMA_URL", "http://x")
+    os.environ.setdefault("OLLAMA_MODEL", "llama3")
+    os.environ.setdefault("HOME_ASSISTANT_URL", "http://ha")
+    os.environ.setdefault("HOME_ASSISTANT_TOKEN", "token")
+    os.environ.pop("API_TOKEN", None)
+    from app import main
+
+    monkeypatch.setattr(main, "ha_startup", lambda: None)
+    monkeypatch.setattr(main, "llama_startup", lambda: None)
+    monkeypatch.setattr(main, "SESSIONS_DIR", tmp_path)
+    return main
+
+
+def test_ws_user_ids_distinct(monkeypatch, tmp_path):
+    main = setup_app(monkeypatch, tmp_path)
+
+    async def fake_transcribe(path: str) -> str:
+        rec = main.log_record_var.get()
+        return rec.user_id if rec else "none"
+
+    monkeypatch.setattr(main, "transcribe_file", fake_transcribe)
+
+    client = TestClient(main.app)
+
+    headers1 = {"Authorization": "Bearer one"}
+    headers2 = {"Authorization": "Bearer two"}
+
+    with client.websocket_connect("/transcribe", headers=headers1) as ws:
+        ws.send_json({"rate": 16000})
+        ws.send_bytes(b"a")
+        data1 = ws.receive_json()
+        ws.send_text("end")
+
+    with client.websocket_connect("/transcribe", headers=headers2) as ws:
+        ws.send_json({"rate": 16000})
+        ws.send_bytes(b"a")
+        data2 = ws.receive_json()
+        ws.send_text("end")
+
+    user1 = data1["text"]
+    user2 = data2["text"]
+    assert user1 == main._anon_user_id(headers1["Authorization"])
+    assert user2 == main._anon_user_id(headers2["Authorization"])
+    assert user1 != user2


### PR DESCRIPTION
### Problem
WebSocket connections to `/transcribe` lacked a user ID when `log_record_var` was empty, resulting in `"local"` being recorded and `ws.state.user_id` remaining unset.

### Solution
- Extend `get_current_user_id` to generate a hashed ID for WebSocket requests when no user ID exists and persist it on `ws.state`.
- Invoke this helper directly from the `/transcribe` WebSocket handler.
- Add regression test ensuring different Authorization headers produce distinct user IDs.

### Tests
`pytest -q tests/test_ws_user_id.py tests/test_transcribe_ws.py`
`ruff check app/deps/user.py tests/test_ws_user_id.py`
`black --check app/deps/user.py app/main.py tests/test_ws_user_id.py`

### Risk
Low – updates are scoped to user ID handling for WebSocket connections.

------
https://chatgpt.com/codex/tasks/task_e_6891074bf980832a89f0b9c24f288121