### PR TITLE
Return GPT response for complex prompts

### DIFF
--- a/app/router.py
+++ b/app/router.py
@@ -13,7 +13,6 @@ from .memory.vector_store import (
     add_user_memory,
     cache_answer,
     lookup_cached_answer,
-    record_feedback,
 )
 from .llama_integration import OLLAMA_MODEL, ask_llama
 from . import llama_integration
@@ -21,7 +20,7 @@ from .telemetry import log_record_var
 from .memory import memgpt
 from .prompt_builder import PromptBuilder, _count_tokens
 from .skills.base import SKILLS as BUILTIN_CATALOG, check_builtin_skills
-from . import skills  # populate built-in registry (SmalltalkSkill, etc.)
+from . import skills  # populate built-in registry (SmalltalkSkill, etc.)  # noqa: F401
 from .intent_detector import detect_intent
 from .deps.user import get_current_user_id
 
@@ -71,7 +70,9 @@ async def route_prompt(
                 rec.cost_usd = ((pt or 0) + (ct or 0)) / 1000 * unit_price
             await append_history(prompt, "gpt", text)
             await record("gpt", fallback=True)
-            memgpt.store_interaction(prompt, text, session_id=session_id, user_id=user_id)
+            memgpt.store_interaction(
+                prompt, text, session_id=session_id, user_id=user_id
+            )
             add_user_memory(user_id, f"Q: {prompt}\nA: {text}")
             cache_answer(norm_prompt, text)
             return text
@@ -147,7 +148,7 @@ async def route_prompt(
         memgpt.store_interaction(prompt, text, session_id=session_id, user_id=user_id)
         add_user_memory(user_id, f"Q: {prompt}\nA: {text}")
         cache_answer(norm_prompt, text)
-        return "ok"
+        return text
 
     # F) Build prompt with context
     built_prompt, ptokens = PromptBuilder.build(

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -1,9 +1,12 @@
-import os, sys
+import os
+import sys
+
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-import pytest
+import pytest  # noqa: E402
 
 import asyncio
 from fastapi import HTTPException
+
 
 def test_router_fallback_metrics_updated(monkeypatch):
     os.environ["OLLAMA_URL"] = "http://x"
@@ -12,8 +15,10 @@ def test_router_fallback_metrics_updated(monkeypatch):
     os.environ["HOME_ASSISTANT_TOKEN"] = "token"
     from app import router, analytics, llama_integration
     from app.memory import vector_store
+
     vector_store.qa_cache.delete(ids=vector_store._qa_cache.get()["ids"])
     llama_integration.LLAMA_HEALTHY = True
+
     async def fake_llama(prompt, model=None):
         return {"error": "timeout", "llm_used": "llama3"}
 
@@ -67,6 +72,7 @@ def test_gpt_override_invalid(monkeypatch):
     os.environ["HOME_ASSISTANT_TOKEN"] = "token"
     from app import router
     from app.memory import vector_store
+
     vector_store.qa_cache.delete(ids=vector_store._qa_cache.get()["ids"])
 
     monkeypatch.setattr(router, "ALLOWED_GPT_MODELS", {"gpt-4"})
@@ -93,10 +99,10 @@ def test_complexity_checks(monkeypatch):
     monkeypatch.setattr(router, "ask_llama", fake_llama)
 
     long_prompt = "word " * 31
-    assert asyncio.run(router.route_prompt(long_prompt, user_id="u")) == "ok"
+    assert asyncio.run(router.route_prompt(long_prompt, user_id="u")) == "gpt"
 
     kw_prompt = "please analyze this"
-    assert asyncio.run(router.route_prompt(kw_prompt, user_id="u")) == "ok"
+    assert asyncio.run(router.route_prompt(kw_prompt, user_id="u")) == "gpt"
 
 
 def test_skill_metrics(monkeypatch):
@@ -142,6 +148,7 @@ def test_debug_env_toggle(monkeypatch):
         return "ok", 0, 0, 0.0
 
     monkeypatch.setattr(router, "ask_gpt", fake_gpt)
+
     async def handle_cmd(prompt):
         return None
 


### PR DESCRIPTION
### Problem
The router's complexity check returned a placeholder string instead of the GPT response, so complex prompts never surfaced the actual model output.

### Solution
- Propagate GPT text from the complexity branch.
- Adjust router tests to expect the real GPT output.
- Clean up imports and format affected files.

### Tests
`ruff check app/router.py tests/test_router.py`
`black --check app/router.py tests/test_router.py`
`pytest tests/test_router.py::test_complexity_checks -q`

### Risk
Low. Changes limited to routing logic and corresponding tests.

------
https://chatgpt.com/codex/tasks/task_e_68910781656c832aa5b19bdc45d675eb