### PR TITLE
Replace API_TOKEN with JWT_SECRET

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,7 +101,7 @@ Skills are tried in the order defined in `app/skills/__init__.py`; first match w
 | `FOLLOW_UPS_FILE` | `data/follow_ups.json` | no | Stored follow-up reminders |
 | `OLLAMA_URL` | `http://localhost:11434` | no | Ollama base URL |
 | `OLLAMA_MODEL` | – | yes | LLaMA model name |
-| `API_TOKEN` | – | no | JWT secret for protected endpoints |
+| `JWT_SECRET` | – | no | JWT secret for protected endpoints |
 | `RATE_LIMIT_PER_MIN` | `60` | no | Requests per minute per IP |
 | `REDIS_URL` | `redis://localhost:6379/0` | no | RQ queue for async tasks |
 | `HISTORY_FILE` | `data/history.jsonl` | no | Request history log |

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Update the copied `.env` with your credentials:
 OPENAI_API_KEY=your_openai_key
 HOME_ASSISTANT_URL=http://your-ha-instance
 HOME_ASSISTANT_TOKEN=your_long_lived_token
+JWT_SECRET=your_jwt_secret
 EMBEDDING_BACKEND=openai  # or "llama"
 # Required when using the LLaMA backend
 LLAMA_EMBEDDINGS_MODEL=/path/to/gguf

--- a/app/deps/user.py
+++ b/app/deps/user.py
@@ -7,7 +7,7 @@ import jwt
 
 from ..telemetry import LogRecord, log_record_var
 
-JWT_SECRET = os.getenv("API_TOKEN")
+JWT_SECRET = os.getenv("JWT_SECRET")
 
 
 def _hash(value: str, length: int = 32) -> str:

--- a/tests/test_sessions_api.py
+++ b/tests/test_sessions_api.py
@@ -28,7 +28,7 @@ def setup_temp(monkeypatch, tmp_path: Path):
     monkeypatch.setattr(store, "SESSIONS_DIR", tmp_path)
     monkeypatch.setattr(history, "HISTORY_FILE", tmp_path / "history.jsonl")
     monkeypatch.setattr(sm, "append_history", history.append_history)
-    monkeypatch.setenv("API_TOKEN", "secret")
+    monkeypatch.setenv("JWT_SECRET", "secret")
 
 
 def _headers() -> dict:

--- a/tests/test_transcribe_ws.py
+++ b/tests/test_transcribe_ws.py
@@ -8,7 +8,7 @@ def setup_app(monkeypatch, tmp_path):
     os.environ.setdefault("OLLAMA_MODEL", "llama3")
     os.environ.setdefault("HOME_ASSISTANT_URL", "http://ha")
     os.environ.setdefault("HOME_ASSISTANT_TOKEN", "token")
-    os.environ["API_TOKEN"] = "secret"
+    os.environ["JWT_SECRET"] = "secret"
     from app import main
 
     monkeypatch.setattr(main, "ha_startup", lambda: None)

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -15,7 +15,7 @@ def test_upload_saves_file(tmp_path, monkeypatch):
     monkeypatch.setattr(main, "ha_startup", lambda: None)
     monkeypatch.setattr(main, "llama_startup", lambda: None)
     monkeypatch.setattr(main, "SESSIONS_DIR", str(tmp_path))
-    monkeypatch.setenv("API_TOKEN", "secret")
+    monkeypatch.setenv("JWT_SECRET", "secret")
 
     client = TestClient(main.app)
     data = b"abc"

--- a/tests/test_ws_user_id.py
+++ b/tests/test_ws_user_id.py
@@ -7,7 +7,7 @@ def setup_app(monkeypatch, tmp_path):
     os.environ.setdefault("OLLAMA_MODEL", "llama3")
     os.environ.setdefault("HOME_ASSISTANT_URL", "http://ha")
     os.environ.setdefault("HOME_ASSISTANT_TOKEN", "token")
-    os.environ.pop("API_TOKEN", None)
+    os.environ.pop("JWT_SECRET", None)
     from app import main
 
     monkeypatch.setattr(main, "ha_startup", lambda: None)


### PR DESCRIPTION
## Summary
- use `JWT_SECRET` environment variable for token verification
- update tests and docs to reference `JWT_SECRET`

## Testing
- `PYENV_VERSION=3.11.12 pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*
- `PYENV_VERSION=3.11.12 ruff check .` *(fails: 86 errors)*
- `PYENV_VERSION=3.11.12 black --check .`


------
https://chatgpt.com/codex/tasks/task_e_689204d905e0832a9bf840ea788a7753