### PR TITLE
Include user id in auth token

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -86,6 +86,6 @@ async def login(
         raise HTTPException(status_code=401, detail="Invalid credentials")
 
     expire = datetime.utcnow() + timedelta(minutes=EXPIRE_MINUTES)
-    payload = {"sub": req.username, "exp": expire}
+    payload = {"sub": req.username, "exp": expire, "user_id": user_id}
     token = jwt.encode(payload, SECRET_KEY, algorithm=ALGORITHM)
     return TokenResponse(access_token=token)

--- a/app/deps/user.py
+++ b/app/deps/user.py
@@ -7,7 +7,7 @@ import jwt
 
 from ..telemetry import LogRecord, log_record_var
 
-JWT_SECRET = os.getenv("API_TOKEN")
+JWT_SECRET = os.getenv("JWT_SECRET")
 
 
 def _hash(value: str, length: int = 32) -> str:

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -27,11 +27,19 @@ def _client(monkeypatch):
 
 def test_login_success(monkeypatch):
     client = _client(monkeypatch)
+
+    def fake_user_id(request: Request) -> str:
+        request.state.user_id = "abc"
+        return "abc"
+
+    client.app.dependency_overrides[get_current_user_id] = fake_user_id
+
     resp = client.post("/login", json={"username": "alice", "password": "wonderland"})
     assert resp.status_code == 200
     token = resp.json()["access_token"]
     payload = jwt.decode(token, "testsecret", algorithms=["HS256"])
     assert payload["sub"] == "alice"
+    assert payload["user_id"] == "abc"
     assert "exp" in payload
 
 


### PR DESCRIPTION
### Problem
JWTs issued at login lacked the current user's identifier and the user resolver looked for `API_TOKEN` instead of `JWT_SECRET`.

### Solution
- Add `user_id` to the `/login` token payload.
- Read `JWT_SECRET` in `get_current_user_id` when decoding a token.
- Test that the login token includes the `user_id` claim.

### Tests
`pytest tests/test_auth.py -q`
`ruff check app/auth.py app/deps/user.py tests/test_auth.py`
`black --check app/auth.py app/deps/user.py tests/test_auth.py`

### Risk
Low: Changes are limited to auth token contents and user ID extraction.

------
https://chatgpt.com/codex/tasks/task_e_689204d9e47c832a8e85cb0360bda3a9