### PR TITLE
Unify login endpoint to return token and stats

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -8,6 +8,7 @@ from passlib.context import CryptContext
 from pydantic import BaseModel
 
 from .deps.user import get_current_user_id
+from .user_store import user_store
 
 # Configuration
 DB_PATH = os.getenv("USERS_DB", "users.db")
@@ -33,17 +34,12 @@ class LoginRequest(BaseModel):
     password: str
 
 
-class TokenResponse(BaseModel):
-    access_token: str
-    token_type: str = "bearer"
-
-
 # Ensure user table exists
 async def _ensure_table() -> None:
     async with aiosqlite.connect(DB_PATH) as db:
         await db.execute(
             """
-            CREATE TABLE IF NOT EXISTS users (
+            CREATE TABLE IF NOT EXISTS auth_users (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 username TEXT UNIQUE NOT NULL,
                 password_hash TEXT NOT NULL
@@ -61,7 +57,7 @@ async def register(req: RegisterRequest, user_id: str = Depends(get_current_user
     try:
         async with aiosqlite.connect(DB_PATH) as db:
             await db.execute(
-                "INSERT INTO users (username, password_hash) VALUES (?, ?)",
+                "INSERT INTO auth_users (username, password_hash) VALUES (?, ?)",
                 (req.username, hashed),
             )
             await db.commit()
@@ -71,14 +67,13 @@ async def register(req: RegisterRequest, user_id: str = Depends(get_current_user
 
 
 # Login endpoint
-@router.post("/login", response_model=TokenResponse)
-async def login(
-    req: LoginRequest, user_id: str = Depends(get_current_user_id)
-) -> TokenResponse:
+@router.post("/login", response_model=dict)
+async def login(req: LoginRequest, user_id: str = Depends(get_current_user_id)) -> dict:
     await _ensure_table()
     async with aiosqlite.connect(DB_PATH) as db:
         async with db.execute(
-            "SELECT password_hash FROM users WHERE username = ?", (req.username,)
+            "SELECT password_hash FROM auth_users WHERE username = ?",
+            (req.username,),
         ) as cursor:
             row = await cursor.fetchone()
 
@@ -88,4 +83,9 @@ async def login(
     expire = datetime.utcnow() + timedelta(minutes=EXPIRE_MINUTES)
     payload = {"sub": req.username, "exp": expire}
     token = jwt.encode(payload, SECRET_KEY, algorithm=ALGORITHM)
-    return TokenResponse(access_token=token)
+
+    await user_store.ensure_user(user_id)
+    await user_store.increment_login(user_id)
+    stats = await user_store.get_stats(user_id)
+
+    return {"token": token, "stats": stats}

--- a/app/main.py
+++ b/app/main.py
@@ -175,14 +175,6 @@ class ServiceRequest(BaseModel):
     data: dict | None = None
 
 
-@app.post("/login")
-async def login(user_id: str = Depends(get_current_user_id)):
-    await user_store.ensure_user(user_id)
-    await user_store.increment_login(user_id)
-    stats = await user_store.get_stats(user_id)
-    return {"user_id": user_id, **stats}
-
-
 @app.get("/me")
 async def get_me(user_id: str = Depends(get_current_user_id)):
     stats = await user_store.get_stats(user_id)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -14,6 +14,7 @@ def _client(monkeypatch):
     db_fd, db_path = tempfile.mkstemp()
     os.close(db_fd)
     monkeypatch.setenv("USERS_DB", db_path)
+    monkeypatch.setenv("USER_DB", db_path)
     monkeypatch.setenv("JWT_SECRET", "testsecret")
     monkeypatch.setenv("JWT_EXPIRE_MINUTES", "5")
     sys.modules.pop("app.auth", None)
@@ -29,10 +30,12 @@ def test_login_success(monkeypatch):
     client = _client(monkeypatch)
     resp = client.post("/login", json={"username": "alice", "password": "wonderland"})
     assert resp.status_code == 200
-    token = resp.json()["access_token"]
+    data = resp.json()
+    token = data["token"]
     payload = jwt.decode(token, "testsecret", algorithms=["HS256"])
     assert payload["sub"] == "alice"
     assert "exp" in payload
+    assert data["stats"]["login_count"] == 1
 
 
 def test_login_bad_credentials(monkeypatch):


### PR DESCRIPTION
### Problem
`/login` was defined in both `main` and `auth`, and the auth handler did not update user statistics or return them with the JWT.

### Solution
- Removed the redundant `/login` handler from `main.py`.
- Updated `auth.login` to ensure the user exists, increment login counts, and respond with `{token, stats}`.
- Revised tests to exercise the unified login route and assert both JWT and stats are returned.

### Tests
- `PYENV_VERSION=3.11.12 black --check .`
- `PYENV_VERSION=3.11.12 ruff check app/auth.py app/main.py tests/test_auth.py tests/test_user_stats.py`
- `PYENV_VERSION=3.11.12 pytest tests/test_auth.py tests/test_user_stats.py -q`

### Risk
- Auth uses a separate `auth_users` table; migrations may be needed if a previous schema is in place.


------
https://chatgpt.com/codex/tasks/task_e_689204dafcf0832ab8d676342cbf25e5