### PR TITLE
Implement token refresh and logout endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,11 +83,29 @@ python record_session.py --duration 5 --output ./sessions
 Authenticate by POSTing to `/login` with a JSON body containing `username` and
 `password`. Valid credentials are supplied via the `LOGIN_USERS` environment
 variable as a JSON object mapping usernames to passwords. A successful login
-returns a JWT access token embedding the user ID in the `sub` claim.
+returns both an access token and a refresh token. Access tokens embed the user
+ID in the `sub` claim and expire after `JWT_EXPIRE_MINUTES` (default 30 minutes).
 
-Tokens expire after `JWT_EXPIRE_MINUTES` (default 30 minutes) to limit risk if a
-token is leaked. There is no long‑lived refresh token yet—clients should simply
-call `/login` again to obtain a fresh token when the previous one expires.
+```bash
+curl -X POST localhost:8000/login \
+     -H "Content-Type: application/json" \
+     -d '{"username":"alice","password":"wonderland"}'
+```
+
+Use the refresh token to obtain a new pair of tokens by POSTing to `/refresh`:
+
+```bash
+curl -X POST localhost:8000/refresh \
+     -H "Content-Type: application/json" \
+     -d '{"refresh_token":"<token>"}'
+```
+
+To explicitly revoke a token, call `/logout` with the token in the Authorization
+header. Revoked token IDs are stored in memory and cannot be reused.
+
+```bash
+curl -X POST localhost:8000/logout -H "Authorization: Bearer <refresh_token>"
+```
 
 ## 🎯 Endpoints
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -29,10 +29,14 @@ def test_login_success(monkeypatch):
     client = _client(monkeypatch)
     resp = client.post("/login", json={"username": "alice", "password": "wonderland"})
     assert resp.status_code == 200
-    token = resp.json()["access_token"]
+    data = resp.json()
+    token = data["access_token"]
+    refresh = data["refresh_token"]
     payload = jwt.decode(token, "testsecret", algorithms=["HS256"])
     assert payload["sub"] == "alice"
-    assert "exp" in payload
+    assert payload["type"] == "access"
+    payload_r = jwt.decode(refresh, "testsecret", algorithms=["HS256"])
+    assert payload_r["type"] == "refresh"
 
 
 def test_login_bad_credentials(monkeypatch):
@@ -56,3 +60,30 @@ def test_login_sets_user_id(monkeypatch):
     resp = client.post("/login", json={"username": "alice", "password": "wonderland"})
     assert resp.status_code == 200
     assert captured["user_id"] == "abc"
+
+
+def test_refresh_and_logout(monkeypatch):
+    client = _client(monkeypatch)
+    resp = client.post("/login", json={"username": "alice", "password": "wonderland"})
+    tokens = resp.json()
+    refresh = tokens["refresh_token"]
+
+    # Refresh should succeed once
+    r2 = client.post("/refresh", json={"refresh_token": refresh})
+    assert r2.status_code == 200
+    new_tokens = r2.json()
+    assert "access_token" in new_tokens
+    assert "refresh_token" in new_tokens
+
+    # Old refresh token is now invalid
+    r3 = client.post("/refresh", json={"refresh_token": refresh})
+    assert r3.status_code == 401
+
+    # Logout with latest refresh token
+    latest_refresh = new_tokens["refresh_token"]
+    r4 = client.post("/logout", headers={"Authorization": f"Bearer {latest_refresh}"})
+    assert r4.status_code == 200
+
+    # Token cannot be used after logout
+    r5 = client.post("/refresh", json={"refresh_token": latest_refresh})
+    assert r5.status_code == 401


### PR DESCRIPTION
### Problem
Tokens could not be refreshed or invalidated.

### Solution
- Issue refresh tokens alongside access tokens
- Add `/refresh` endpoint to rotate tokens
- Add `/logout` to revoke tokens in-memory
- Document usage with curl examples

### Tests
`PYENV_VERSION=3.11.12 pytest tests/test_auth.py -q`
`PYENV_VERSION=3.11.12 ruff check .` *(fails: multiple existing lint errors)*
`PYENV_VERSION=3.11.12 python -m black --check .`

### Risk
In-memory blacklist does not persist across restarts; full test suite and lint checks require additional dependencies.


------
https://chatgpt.com/codex/tasks/task_e_689204ddc6cc832a94f20be7cb457396