### PR TITLE
refactor: simplify user id fallback and enforce ip rate limiting

### DIFF
--- a/tests/test_user_id_by_ip.py
+++ b/tests/test_user_id_by_ip.py
@@ -1,25 +1,37 @@
-from hashlib import sha256
-
 from fastapi import Depends
 from fastapi.testclient import TestClient
 
 from app.deps.user import get_current_user_id
+from app.security import rate_limit
 from app.main import app
+import app.security as security
 
 
 @app.get("/whoami")
-async def whoami(user_id: str = Depends(get_current_user_id)):
+async def whoami(
+    user_id: str = Depends(get_current_user_id),
+    _: None = Depends(rate_limit),
+):
     return {"user_id": user_id}
 
 
-def test_unauthenticated_requests_from_different_ips_have_distinct_ids():
+def test_unauthenticated_requests_are_rate_limited_per_ip(monkeypatch):
     client = TestClient(app)
+    monkeypatch.setattr(security, "RATE_LIMIT", 1)
+    security._requests.clear()
+
     ip1 = "1.1.1.1"
     ip2 = "2.2.2.2"
-    r1 = client.get("/whoami", headers={"X-Forwarded-For": ip1})
-    r2 = client.get("/whoami", headers={"X-Forwarded-For": ip2})
-    uid1 = r1.json()["user_id"]
-    uid2 = r2.json()["user_id"]
-    assert uid1 == sha256(ip1.encode("utf-8")).hexdigest()[:12]
-    assert uid2 == sha256(ip2.encode("utf-8")).hexdigest()[:12]
-    assert uid1 != uid2
+    h1 = {"X-Forwarded-For": ip1, "Authorization": "Token A"}
+    h2 = {"X-Forwarded-For": ip2, "Authorization": "Token B"}
+
+    r1 = client.get("/whoami", headers=h1)
+    assert r1.status_code == 200
+    assert r1.json()["user_id"] == "anon"
+
+    r2 = client.get("/whoami", headers=h1)
+    assert r2.status_code == 429
+
+    r3 = client.get("/whoami", headers=h2)
+    assert r3.status_code == 200
+    assert r3.json()["user_id"] == "anon"


### PR DESCRIPTION
### Problem
user identification fell back to hashed headers/IPs without explicit per-ip rate limiting.

### Solution
- drop hashing of auth headers and client IPs in `get_current_user_id`
- rate limit unauthenticated requests by raw IP via `rate_limit`
- test per-IP limiting without hashed identifiers

### Tests
`pytest -q`
`python -m ruff check app/deps/user.py app/security.py tests/test_user_id_by_ip.py`
`black --check app/deps/user.py app/security.py tests/test_user_id_by_ip.py`

### Risk
low; touches authentication fallback and rate limiting paths for unauthenticated users.

------
https://chatgpt.com/codex/tasks/task_e_689204e092f8832a94a2fc30b7c5a3a6