### PR TITLE
Refactor model routing with helper

### DIFF
--- a/app/model_picker.py
+++ b/app/model_picker.py
@@ -1,0 +1,31 @@
+"""Helper to choose between LLaMA and GPT models."""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+from .llama_integration import OLLAMA_MODEL
+
+
+GPT_DEFAULT_MODEL = "gpt-4o"
+
+
+def pick_model(prompt: str, intent: str, tokens: int) -> Tuple[str, str]:
+    """Return (engine, model_name) for the given prompt.
+
+    ``engine`` is ``"llama"`` or ``"gpt"``; ``model_name`` is the concrete
+    model for that engine.  The heuristic mirrors the previous logic in
+    :mod:`app.router` and considers prompt length, intent, and token count.
+    """
+
+    keywords = {"code", "research", "analyze", "explain"}
+    heavy_intents = {"analysis", "research"}
+    words = prompt.lower().split()
+    if (
+        len(words) > 30
+        or any(k in words for k in keywords)
+        or tokens > 1000
+        or intent in heavy_intents
+    ):
+        return "gpt", GPT_DEFAULT_MODEL
+    return "llama", OLLAMA_MODEL or "llama"

--- a/tests/test_model_picker.py
+++ b/tests/test_model_picker.py
@@ -1,0 +1,25 @@
+import os
+
+os.environ["OLLAMA_MODEL"] = "llama3"
+
+from app.model_picker import pick_model, GPT_DEFAULT_MODEL
+from app.llama_integration import OLLAMA_MODEL
+
+
+def test_pick_model_llama():
+    engine, model = pick_model("hello", "chat", 5)
+    assert engine == "llama"
+    assert model == OLLAMA_MODEL or model == "llama3"
+
+
+def test_pick_model_complex_long():
+    prompt = "word " * 31
+    engine, model = pick_model(prompt, "chat", 0)
+    assert engine == "gpt"
+    assert model == GPT_DEFAULT_MODEL
+
+
+def test_pick_model_keyword():
+    engine, model = pick_model("please analyze this", "chat", 0)
+    assert engine == "gpt"
+    assert model == GPT_DEFAULT_MODEL


### PR DESCRIPTION
### Problem
Model selection between local LLaMA and GPT was embedded directly in `route_prompt`, complicating maintenance and testing.

### Solution
* Introduced `ModelPicker` helper to encapsulate model-choice heuristics.
* Refactored `route_prompt` to delegate engine/model selection to this helper.
* Added unit tests verifying ModelPicker behavior.

### Tests
- `PYENV_VERSION=3.11.12 pytest tests/test_model_picker.py tests/test_router.py -q`
- `PYENV_VERSION=3.11.12 pytest -q` *(fails: capture auth & auth DB tests)*
- `PYENV_VERSION=3.11.12 ruff check app/model_picker.py app/router.py tests/test_model_picker.py`
- `PYENV_VERSION=3.11.12 black --check app/model_picker.py app/router.py tests/test_model_picker.py`

### Risk
Model selection heuristics may need adjustment for additional intents or token thresholds.

------
https://chatgpt.com/codex/tasks/task_e_68921d9840dc832ab045e42ec6778468