### PR TITLE
Handle smalltalk intent for short greetings

### DIFF
--- a/app/intent_detector.py
+++ b/app/intent_detector.py
@@ -1,5 +1,12 @@
+"""Simple heuristic intent detector."""
+
+from .skills.smalltalk_skill import is_greeting
+
+
 def detect_intent(prompt: str) -> tuple[str, str]:
     prompt_l = prompt.lower()
+    if is_greeting(prompt):
+        return "smalltalk", "low"
     if any(kw in prompt_l for kw in ("turn on", "turn off")):
         return "control", "high"
     if len(prompt_l.split()) < 10:

--- a/app/router.py
+++ b/app/router.py
@@ -50,6 +50,15 @@ async def route_prompt(
     norm_prompt = prompt.lower().strip()
 
     intent, priority = detect_intent(prompt)
+    if intent == "smalltalk":
+        from .skills.smalltalk_skill import SmalltalkSkill
+
+        skill_resp = await SmalltalkSkill().handle(prompt)
+        if rec:
+            rec.engine_used = "skill"
+        await append_history(prompt, "skill", str(skill_resp))
+        await record("done", source="skill")
+        return skill_resp
     skip_skills = intent == "chat" and priority == "high"
 
     # A) Model override if using GPT

--- a/tests/test_intent_detector.py
+++ b/tests/test_intent_detector.py
@@ -1,0 +1,10 @@
+import os, sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from app.intent_detector import detect_intent
+
+
+def test_short_greeting_classification():
+    assert detect_intent("hi") == ("smalltalk", "low")
+    assert detect_intent("hello") == ("smalltalk", "low")


### PR DESCRIPTION
### Problem
Short one-word greetings like "hi" or "hello" were categorized as generic chat, so the router always ran through the full skill check pipeline.

### Solution
- Detect short greeting intents as `(smalltalk, low)`.
- Allow `route_prompt` to handle this intent by invoking the Smalltalk skill directly and skipping further skill checks.
- Added a regression test for the new intent classification.

### Tests
`PYENV_VERSION=3.11.12 python -m pytest tests/test_intent_detector.py tests/test_smalltalk.py tests/test_router.py tests/test_llama_health.py -q`
`PYENV_VERSION=3.11.12 python -m pytest -q` *(fails: tests/test_capture_auth.py::test_capture_start_sets_user_id_from_token, tests/test_capture_auth.py::test_capture_start_invalid_token, tests/test_register.py::test_register_and_duplicate, tests/test_user_stats.py::test_login_and_me)*
`PYENV_VERSION=3.11.12 ruff check .`
`PYENV_VERSION=3.11.12 black --check .`

### Risk
Limited set of greetings recognized; further additions may be needed for broader coverage.

------
https://chatgpt.com/codex/tasks/task_e_68921d996690832aac6e8f2a94ba6f3d