### PR TITLE
[core] OpenAI client lifecycle & transcription hardening

### DIFF
--- a/app/transcribe.py
+++ b/app/transcribe.py
@@ -2,7 +2,6 @@ import os
 import logging
 import openai
 
-OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
 WHISPER_MODEL = os.getenv("WHISPER_MODEL", "whisper-1")
 
 logger = logging.getLogger(__name__)
@@ -11,9 +10,12 @@ logger = logging.getLogger(__name__)
 def transcribe_file(path: str, model: str | None = None) -> str:
     """Transcribe the given audio file using OpenAI's Whisper API."""
     model = model or WHISPER_MODEL
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        raise RuntimeError("OPENAI_API_KEY not set")
     try:
         with open(path, "rb") as fh:
-            resp = openai.Audio.transcribe(model=model, file=fh, api_key=OPENAI_API_KEY)
+            resp = openai.Audio.transcribe(model=model, file=fh, api_key=api_key)
         if isinstance(resp, dict):
             text = resp.get("text", "")
         else:

--- a/tests/test_api_key.py
+++ b/tests/test_api_key.py
@@ -1,0 +1,21 @@
+from importlib import reload
+
+import pytest
+
+from app import gpt_client
+
+
+def test_get_client_missing_key(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    gpt_client._client = None
+    with pytest.raises(RuntimeError):
+        gpt_client.get_client()
+
+
+@pytest.mark.asyncio
+async def test_close_client_double(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "x")
+    reload(gpt_client)
+    gpt_client.get_client()
+    await gpt_client.close_client()
+    await gpt_client.close_client()

--- a/tests/test_transcription_errors.py
+++ b/tests/test_transcription_errors.py
@@ -1,0 +1,62 @@
+from importlib import reload
+import wave
+
+import pytest
+from fastapi import HTTPException
+
+from app import transcription
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "setup,exc,matcher",
+    [
+        ("missing", HTTPException, "file_not_found"),
+        ("empty", ValueError, "empty_transcription"),
+    ],
+)
+async def test_transcription_errors(tmp_path, monkeypatch, setup, exc, matcher):
+    monkeypatch.setenv("OPENAI_API_KEY", "x")
+    reload(transcription)
+    if setup == "missing":
+        path = tmp_path / "nope.wav"
+    else:
+        path = tmp_path / "empty.wav"
+        with wave.open(str(path), "wb") as w:
+            w.setnchannels(1)
+            w.setsampwidth(2)
+            w.setframerate(16000)
+            w.writeframes(b"")
+
+        class Resp:
+            text = ""
+
+        async def fake_create(*args, **kwargs):
+            return Resp()
+
+        transcription._client = type(
+            "C",
+            (),
+            {
+                "audio": type(
+                    "A",
+                    (),
+                    {"transcriptions": type("T", (), {"create": fake_create})()},
+                )()
+            },
+        )()
+
+    with pytest.raises(exc) as e:
+        await transcription.transcribe_file(str(path))
+    assert matcher in str(e.value)
+    if isinstance(e.value, HTTPException):
+        assert e.value.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_close_whisper_client_double(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "x")
+    reload(transcription)
+    transcription.get_whisper_client()
+    await transcription.close_whisper_client()
+    await transcription.close_whisper_client()


### PR DESCRIPTION
## Summary
- centralize AsyncOpenAI client creation/cleanup and expose close_client
- harden Whisper transcription helper with runtime key lookup, logging, and validation
- add FastAPI shutdown hook to close GPT and Whisper clients

## Testing
- `ruff check .` *(fails: Multiple imports on one line, unused imports, etc.)*
- `ruff format .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic', etc.)*
- `pytest tests/test_api_key.py tests/test_transcription_errors.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689257fcd9b4832a95ca980d36c59c4e