### PR TITLE
Ensure JWT auth works in tests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,8 @@
+import os
+
+import pytest
+
+# Ensure asynchronous tests have an event loop available and JWT auth works.
+os.environ.setdefault("JWT_SECRET", "secret")
+
+pytest_plugins = ("pytest_asyncio",)

--- a/tests/test_api_key.py
+++ b/tests/test_api_key.py
@@ -4,6 +4,8 @@ import pytest
 
 from app import gpt_client
 
+# Async test relies on pytest-asyncio to provide an event loop
+
 
 def test_get_client_missing_key(monkeypatch):
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)

--- a/tests/test_capture_auth.py
+++ b/tests/test_capture_auth.py
@@ -10,9 +10,11 @@ import app.deps.user as user_deps
 
 def _build_client(monkeypatch):
     monkeypatch.setattr(security, "API_TOKEN", "secret")
+    monkeypatch.setattr(security, "JWT_SECRET", "secret")
     monkeypatch.setattr(user_deps, "JWT_SECRET", "secret")
     monkeypatch.setattr(security, "_http_requests", {})
     monkeypatch.setattr(security, "_ws_requests", {})
+    monkeypatch.setenv("JWT_SECRET", "secret")
 
     app = FastAPI()
     captured: dict[str, Any] = {}


### PR DESCRIPTION
### Problem
Async tests lacked an event loop and JWT-protected endpoints were missing a configured secret, causing middleware to skip token verification.

### Solution
- Provide a test-wide `JWT_SECRET` and load `pytest-asyncio` via `conftest.py`.
- Patch security modules in capture auth tests to use the secret and include the header.
- Clarify async test dependency on `pytest-asyncio` in API key tests.

### Tests
- `PYENV_VERSION=3.11.12 python -m pytest tests/test_api_key.py tests/test_capture_auth.py -q`
- `PYENV_VERSION=3.11.12 pytest -q` *(fails: ModuleNotFoundError: No module named 'aiofiles', ...)*
- `PYENV_VERSION=3.11.12 ruff check .` *(fails: 74 errors)*
- `PYENV_VERSION=3.11.12 black --check .` *(fails: would reformat app/security.py, tests/test_rate_limit.py)*

### Risk
Low. Changes affect test configuration and JWT auth tests only.

------
https://chatgpt.com/codex/tasks/task_e_68926d76a448832ab806d5b53aea5cb1