### PR TITLE
Fix SIM_THRESHOLD env in config tests

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,4 +1,5 @@
-import os, sys
+import os
+import sys
 from fastapi.testclient import TestClient
 from importlib import reload
 import time
@@ -16,6 +17,7 @@ def setup_app(monkeypatch):
 
     os.environ["OPENAI_API_KEY"] = "key"
     os.environ["OPENAI_MODEL"] = "gpt"
+    os.environ["SIM_THRESHOLD"] = "0.90"
     import app.home_assistant as home_assistant
     import app.llama_integration as llama_integration
     import app.status as status
@@ -58,4 +60,5 @@ def test_config_env_reload(monkeypatch):
     resp = client.get("/config", params={"token": "secret"})
     assert resp.json()["DEBUG"] == "1"
     env.unlink()
+    data = resp.json()
     assert data["SIM_THRESHOLD"] == "0.90"


### PR DESCRIPTION
### Problem
Config tests could inherit an unexpected `SIM_THRESHOLD` from the environment, producing inconsistent results.

### Solution
Explicitly set `SIM_THRESHOLD` to `"0.90"` in the test setup and collect response data before asserting the value.

### Tests
`python -m pytest tests/test_config.py::test_config_env_reload --disable-warnings`
`PYENV_VERSION=3.11.12 ruff check tests/test_config.py`
`PYENV_VERSION=3.11.12 black --check tests/test_config.py`

### Risk
Low; only affects test configuration.

------
https://chatgpt.com/codex/tasks/task_e_6892a40a8bec832ab09cbf72c05213d6