### PR TITLE
Require REDIS_URL to use background queue

### DIFF
--- a/app/tasks.py
+++ b/app/tasks.py
@@ -28,7 +28,9 @@ from .memory.vector_store import add_user_memory
 def _get_queue() -> Queue:
     if Redis is None or Queue is None:
         raise RuntimeError("redis/rq not installed")
-    url = os.getenv("REDIS_URL", "redis://localhost:6379/0")
+    url = os.getenv("REDIS_URL")
+    if not url:
+        raise RuntimeError("REDIS_URL not configured")
     conn = Redis.from_url(url)
     return Queue("default", connection=conn)
 


### PR DESCRIPTION
### Problem
Background tasks defaulted to Redis even when `REDIS_URL` was unset, causing queue operations to fail silently instead of running synchronously.

### Solution
`_get_queue` now raises when `REDIS_URL` is missing, forcing `enqueue_transcription`, `enqueue_tag_extraction`, and `enqueue_summary` to execute inline when no queue is configured.

### Tests
`ruff check .` *(fails: existing lint errors)*
`black --check .`
`pytest tests/test_sessions_api.py::test_capture_flow -q`
`pytest tests/test_sessions_api.py::test_manual_pipeline -q`

### Risk
Low. Environments without `REDIS_URL` run tasks synchronously, making behavior explicit.

------
https://chatgpt.com/codex/tasks/task_e_6892a4158424832a91cf2b5e14b41fb9