### PR TITLE
refactor: replace capture mode buttons with UI component

### DIFF
--- a/frontend/src/components/CaptureMode.tsx
+++ b/frontend/src/components/CaptureMode.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { Button } from '@/components/ui/button';
 
 // Determine supported mime types for media recording
 // (defaults will be refined once the component mounts)
@@ -209,9 +210,9 @@ export default function CaptureMode() {
     return (
       <div className="p-4">
         <p>{error}</p>
-        <button onClick={setupStream} className="mt-2 px-3 py-1 bg-blue-500 text-white rounded">
+        <Button onClick={setupStream} className="mt-2">
           Retry
-        </button>
+        </Button>
       </div>
     );
   }
@@ -226,30 +227,18 @@ export default function CaptureMode() {
         </div>
       </div>
       <div className="flex items-center gap-2">
-        <button
-          onClick={startRecording}
-          disabled={recording}
-          className="px-2 py-1 bg-green-500 text-white rounded"
-        >
+        <Button onClick={startRecording} disabled={recording} variant="default">
           ▶️ Start Recording
-        </button>
-        <button
-          onClick={pauseRecording}
-          disabled={!recording}
-          className="px-2 py-1 bg-yellow-500 text-white rounded"
-        >
+        </Button>
+        <Button onClick={pauseRecording} disabled={!recording} variant="secondary">
           ⏸️ Pause Recording
-        </button>
-        <button
-          onClick={stopRecording}
-          disabled={!recording}
-          className="px-2 py-1 bg-red-500 text-white rounded"
-        >
+        </Button>
+        <Button onClick={stopRecording} disabled={!recording} variant="destructive">
           ⏹️ Stop & Save
-        </button>
-        <button onClick={newQuestion} className="px-2 py-1 bg-blue-500 text-white rounded">
+        </Button>
+        <Button onClick={newQuestion} variant="default">
           🔄 New Question
-        </button>
+        </Button>
         <div className="ml-4 w-24 h-2 bg-gray-300">
           <div
             className="h-full bg-green-500"


### PR DESCRIPTION
### Problem
Capture mode used raw `<button>` elements with custom classes, leading to inconsistent styling.

### Solution
- Import shared `Button` component.
- Replace control and error buttons with `Button` variants while preserving disabled states.

### Tests
`pytest -q` *(fails: ModuleNotFoundError: No module named 'pytest_asyncio')*
`ruff check .` *(fails: 74 errors)*
`black --check .`

### Risk
- Styling changes may require additional tweaks if variant choices don't perfectly match prior colors.

------
https://chatgpt.com/codex/tasks/task_e_6892a53e06e4832abdc8fe306b570a6c