### PR TITLE
Fix model override routing and OpenAI fallback

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,6 +155,11 @@ ruff check .
 black --check .
 ```
 
+## Model Routing Rules
+- Accept `model_override` from frontend POST body.
+- Route `"llama*"` models to `ask_llama()`, `"gpt*"` models to `ask_gpt()`.
+- If OpenAI dependency is missing, fallback to LLaMA instead of failing.
+
 ## Skill-Authoring Checklist
 - Copy `app/skills/example_skill.py` style into a new `<name>_skill.py`.
 - Implement a `Skill` subclass with `PATTERNS` and `run()`.

--- a/app/gpt_client.py
+++ b/app/gpt_client.py
@@ -19,7 +19,10 @@ import os
 
 try:  # pragma: no cover - exercised when openai is installed
     from openai import AsyncOpenAI
+
+    OPENAI_AVAILABLE = True
 except Exception:  # pragma: no cover - executed when dependency missing
+    OPENAI_AVAILABLE = False
 
     class AsyncOpenAI:  # type: ignore[misc]
         """Fallback used when the ``openai`` package isn't available."""
@@ -52,6 +55,8 @@ def get_client() -> AsyncOpenAI:
     """
 
     global _client
+    if not OPENAI_AVAILABLE:
+        raise RuntimeError("openai package not installed")
     if _client is None:
         api_key = os.getenv("OPENAI_API_KEY")
         if not api_key:

--- a/app/main.py
+++ b/app/main.py
@@ -24,7 +24,7 @@ from fastapi import (
     Form,
 )
 from fastapi.middleware.cors import CORSMiddleware
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from fastapi import Depends, Request
 from .deps.user import get_current_user_id
 from .user_store import user_store
@@ -178,7 +178,10 @@ async def shutdown_event() -> None:
 
 class AskRequest(BaseModel):
     prompt: str
-    model: str | None = None
+    model_override: str | None = Field(None, alias="model")
+
+    class Config:
+        allow_population_by_field_name = True
 
 
 class ServiceRequest(BaseModel):
@@ -199,7 +202,7 @@ async def get_me(user_id: str = Depends(get_current_user_id)):
 async def ask(req: AskRequest, user_id: str = Depends(get_current_user_id)):
     logger.info("Received prompt: %s", req.prompt)
     try:
-        answer = await route_prompt(req.prompt, req.model, user_id)
+        answer = await route_prompt(req.prompt, req.model_override, user_id)
         return {"response": answer}
     except HTTPException as exc:
         raise exc


### PR DESCRIPTION
## Summary
- honor `model_override` in /ask and support LLaMA model overrides
- gracefully fall back to LLaMA when OpenAI is unavailable
- document model routing rules in AGENTS.md

## Testing
- `ruff check app/main.py app/router.py app/gpt_client.py`
- `black --check app/main.py app/router.py app/gpt_client.py`


------
https://chatgpt.com/codex/tasks/task_e_6892b97f5d0c832ab21ca8dfc378bcc5