### PR TITLE
Ping LLaMA via generation for health check

### DIFF
--- a/app/status.py
+++ b/app/status.py
@@ -76,6 +76,7 @@ async def ha_status(user_id: str = Depends(get_current_user_id)) -> dict:
 
 @router.get("/llama_status")
 async def llama_status(user_id: str = Depends(get_current_user_id)) -> dict:
+    """Report LLaMA health by attempting a minimal generation."""
     try:
         return await llama_get_status()
     except Exception:

--- a/tests/test_llama.py
+++ b/tests/test_llama.py
@@ -1,7 +1,7 @@
-import sys, os
+import os
+import sys
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-import pytest
 
 import asyncio
 
@@ -14,7 +14,7 @@ class DummyResponse:
         pass
 
     def json(self):
-        return {}
+        return {"response": "pong"}
 
 
 class DummyClient:
@@ -24,7 +24,7 @@ class DummyClient:
     async def __aexit__(self, exc_type, exc, tb):
         pass
 
-    async def get(self, url):
+    async def request(self, method, url, **kwargs):
         return DummyResponse()
 
 
@@ -40,3 +40,4 @@ def test_llama_status_returns_healthy(monkeypatch):
     )
     res = asyncio.run(llama_integration.get_status())
     assert res["status"] == "healthy"
+    assert "latency_ms" in res


### PR DESCRIPTION
### Problem
The LLaMA health probe only queried `/api/tags`, so a successful response didn’t guarantee the model could actually generate text. The status endpoint also lacked latency reporting for generation.

### Solution
- Perform a minimal generation (`"ping"` with one predicted token) in `_check_and_set_flag` and mark the global health flag based on the response.
- Measure and expose latency for this generation in `get_status`.
- Update `/llama_status` endpoint docs to reflect the generation check.
- Adjust unit test to mock the new POST call and assert latency presence.

### Tests
`black --check tests/test_llama.py app/llama_integration.py app/status.py`
`ruff check app/llama_integration.py app/status.py tests/test_llama.py`
`pytest -q` *(fails: assert 500 == 200; NameError `_call_gpt`; etc.)*

### Risk
- Requires running Ollama’s generate API; failures or slow responses will mark LLaMA as unhealthy.


------
https://chatgpt.com/codex/tasks/task_e_6892dde16800832aba784a8eb253e6a2