### PR TITLE
Add scheduler shutdown call

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -72,6 +72,7 @@ from .tasks import enqueue_transcription, enqueue_summary
 from .security import verify_token, rate_limit, verify_ws, rate_limit_ws
 from .analytics import record_latency, latency_p95
 from .gpt_client import close_client
+from .deps.scheduler import shutdown as scheduler_shutdown
 
 configure_logging()
 logger = logging.getLogger(__name__)
@@ -182,6 +183,11 @@ async def shutdown_event() -> None:
             await func()
         except Exception as e:
             logger.debug("shutdown cleanup failed: %s", e)
+
+    try:
+        scheduler_shutdown()
+    except Exception as e:
+        logger.debug("scheduler shutdown failed: %s", e)
 
 
 class AskRequest(BaseModel):


### PR DESCRIPTION
### Problem
Scheduler was not stopped when the FastAPI app shut down.

### Solution
Import `shutdown` from `app.deps.scheduler` and call it inside the existing `@app.on_event("shutdown")` handler to ensure the scheduler is gracefully closed.

### Tests
`pytest -q` *(fails: ModuleNotFoundError: aiofiles, jose, aiosqlite)*
`ruff check .` *(fails: 69 errors)*
`black --check .` *(fails: would reformat app/router.py)*

### Risk
Low. The change adds a guarded shutdown call and should not affect runtime except during application teardown.

------
https://chatgpt.com/codex/tasks/task_e_6893676be818832a8a94fa933d945b78