### PR TITLE
Preserve metadata on logged async functions

### DIFF
--- a/app/http_utils.py
+++ b/app/http_utils.py
@@ -1,6 +1,7 @@
 import asyncio
 import importlib
 import logging
+from functools import wraps
 from typing import Tuple
 
 import httpx
@@ -12,6 +13,7 @@ def log_exceptions(module: str):
     """Decorator to log exceptions for async functions."""
 
     def decorator(func):
+        @wraps(func)
         async def wrapper(*args, **kwargs):
             try:
                 return await func(*args, **kwargs)


### PR DESCRIPTION
### Problem
`log_exceptions` decorator wrapped async functions without preserving their original metadata.

### Solution
Import `functools.wraps` and apply `@wraps(func)` to the generated wrapper inside `log_exceptions` so that wrapped functions retain their name and docstring.

### Tests
`pytest -q` *(fails: JSONDecodeError, etc.)*
`ruff check .` *(69 errors)*
`black --check .` *(1 file would be reformatted)*

### Risk
Low; change only adds metadata preservation to decorator.

------
https://chatgpt.com/codex/tasks/task_e_6893676d6570832aa341d40723d2b41d