### PR TITLE
Propagate HTTPException status in /ask streaming

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -211,16 +211,19 @@ async def ask(req: AskRequest, user_id: str = Depends(get_current_user_id)):
     logger.info("Received prompt: %s", req.prompt)
 
     queue: asyncio.Queue[str | None] = asyncio.Queue()
+    status_code: int | None = None
 
     async def _stream_cb(token: str) -> None:
         await queue.put(token)
 
     async def _producer() -> None:
+        nonlocal status_code
         try:
             await route_prompt(
                 req.prompt, req.model_override, user_id, stream_cb=_stream_cb
             )
         except HTTPException as exc:
+            status_code = exc.status_code
             await queue.put(f"[error:{exc.detail}]")
         except Exception as e:  # pragma: no cover - defensive
             logger.exception("Error processing prompt: %s", e)
@@ -230,14 +233,20 @@ async def ask(req: AskRequest, user_id: str = Depends(get_current_user_id)):
 
     asyncio.create_task(_producer())
 
+    first_chunk = await queue.get()
+
     async def _streamer():
+        if first_chunk is not None:
+            yield first_chunk
         while True:
             chunk = await queue.get()
             if chunk is None:
                 break
             yield chunk
 
-    return StreamingResponse(_streamer(), media_type="text/plain")
+    return StreamingResponse(
+        _streamer(), media_type="text/plain", status_code=status_code or 200
+    )
 
 
 @app.post("/upload")

--- a/tests/test_stream_status.py
+++ b/tests/test_stream_status.py
@@ -1,0 +1,32 @@
+import os
+import sys
+from fastapi.testclient import TestClient
+from fastapi import HTTPException
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+
+def setup_app(monkeypatch):
+    os.environ["OLLAMA_URL"] = "http://x"
+    os.environ["OLLAMA_MODEL"] = "llama3"
+    os.environ["HOME_ASSISTANT_URL"] = "http://ha"
+    os.environ["HOME_ASSISTANT_TOKEN"] = "token"
+    from app import main
+
+    monkeypatch.setattr(main, "ha_startup", lambda: None)
+    monkeypatch.setattr(main, "llama_startup", lambda: None)
+    return main
+
+
+def test_streaming_sets_status_code(monkeypatch):
+    main = setup_app(monkeypatch)
+
+    async def fail(*args, **kwargs):
+        raise HTTPException(status_code=418, detail="teapot")
+
+    monkeypatch.setattr(main, "route_prompt", fail)
+
+    client = TestClient(main.app)
+    resp = client.post("/ask", json={"prompt": "hi"})
+    assert resp.status_code == 418
+    assert resp.text == "[error:teapot]"


### PR DESCRIPTION
### Problem
`/ask` always returned 200 even when `route_prompt` raised `HTTPException`, forcing clients to parse error tokens for failures.

### Solution
Capture the raised `HTTPException`, await the first streamed chunk, and apply its `status_code` to the final `StreamingResponse`. Added a regression test ensuring the correct status is surfaced.

### Tests
`PYENV_VERSION=3.11.12 pytest tests/test_stream_status.py -vv`
`PYENV_VERSION=3.11.12 ruff check .` *(fails: E401, F401, ...)*
`PYENV_VERSION=3.11.12 black --check .` *(fails: would reformat app/router.py)*

### Risk
Low – only adjusts error handling for the `/ask` streaming endpoint.

------
https://chatgpt.com/codex/tasks/task_e_68936768d888832ab07aa94206ba980b