### PR TITLE
feat: add explicit cache_answer signature

### DIFF
--- a/app/router.py
+++ b/app/router.py
@@ -292,7 +292,7 @@ async def _call_gpt_override(
     await record("gpt", source="override")
     memgpt.store_interaction(prompt, text, session_id=session_id, user_id=user_id)
     add_user_memory(user_id, f"Q: {prompt}\nA: {text}")
-    cache_answer(norm_prompt, text)
+    cache_answer(prompt=norm_prompt, answer=text)
     return text
 
 
@@ -328,7 +328,7 @@ async def _call_llama_override(
         prompt, result_text, session_id=session_id, user_id=user_id
     )
     add_user_memory(user_id, f"Q: {prompt}\nA: {result_text}")
-    cache_answer(norm_prompt, result_text)
+    cache_answer(prompt=norm_prompt, answer=result_text)
     return result_text
 
 
@@ -356,7 +356,7 @@ async def _call_gpt(
         rec.response = text
     memgpt.store_interaction(prompt, text, session_id=session_id, user_id=user_id)
     add_user_memory(user_id, f"Q: {prompt}\nA: {text}")
-    cache_answer(norm_prompt, text)
+    cache_answer(prompt=norm_prompt, answer=text)
     return await _finalise("gpt", prompt, text, rec)
 
 
@@ -392,7 +392,7 @@ async def _call_llama(
         prompt, result_text, session_id=session_id, user_id=user_id
     )
     add_user_memory(user_id, f"Q: {prompt}\nA: {result_text}")
-    cache_answer(norm_prompt, result_text)
+    cache_answer(prompt=norm_prompt, answer=result_text)
     return await _finalise("llama", prompt, result_text, rec)
 
 


### PR DESCRIPTION
### Problem
`cache_answer` accepted arbitrary positional arguments, making its usage unclear and error‑prone.

### Solution
- Introduced an explicit `cache_answer(prompt, answer, cache_id=None)` signature.
- Added `cache_answer_legacy` wrapper for backward compatibility.
- Updated router to cache answers using named parameters.

### Tests
`venv/bin/black --check app/memory/vector_store.py app/router.py`
`venv/bin/ruff check app/memory/vector_store.py app/router.py`
`venv/bin/pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

### Risk
- External callers using the old positional API must migrate or switch to `cache_answer_legacy`.

------
https://chatgpt.com/codex/tasks/task_e_68937114cfdc832a85d37215d60cdf63