### PR TITLE
feat: add env flag helper

### DIFF
--- a/app/memory/vector_store.py
+++ b/app/memory/vector_store.py
@@ -35,6 +35,17 @@ from typing import Dict, List, Optional, Tuple
 
 
 # ---------------------------------------------------------------------------
+# Environment helpers
+# ---------------------------------------------------------------------------
+
+
+def _env_flag(name: str) -> bool:
+    """Return True if the environment variable is set to a truthy value."""
+
+    return os.getenv(name, "").strip().lower() in {"true", "1", "yes"}
+
+
+# ---------------------------------------------------------------------------
 # Normalisation helpers
 # ---------------------------------------------------------------------------
 
@@ -250,7 +261,7 @@ class ChromaVectorStore(VectorStore):
         return self._cache
 
     def cache_answer(self, cache_id: str, prompt: str, answer: str) -> None:
-        if bool(os.getenv("DISABLE_QA_CACHE")):
+        if _env_flag("DISABLE_QA_CACHE"):
             return
         _, norm = _normalize(prompt)
         self._cache.upsert(
@@ -262,7 +273,7 @@ class ChromaVectorStore(VectorStore):
     def lookup_cached_answer(
         self, prompt: str, ttl_seconds: int = 86400
     ) -> Optional[str]:
-        if bool(os.getenv("DISABLE_QA_CACHE")):
+        if _env_flag("DISABLE_QA_CACHE"):
             return None
         _, norm = _normalize(prompt)
         q_len = len(norm)
@@ -285,7 +296,7 @@ class ChromaVectorStore(VectorStore):
         return best_rec.answer
 
     def record_feedback(self, prompt: str, feedback: str) -> None:
-        if bool(os.getenv("DISABLE_QA_CACHE")):
+        if _env_flag("DISABLE_QA_CACHE"):
             return
         cache_id = _normalized_hash(prompt)
         rec = self._cache._store.get(cache_id)


### PR DESCRIPTION
### Problem
`bool(os.getenv("DISABLE_QA_CACHE"))` treats any non-empty value as true, so flags like "false" or "0" inadvertently disable the QA cache.

### Solution
Introduce `_env_flag` to parse environment variables and treat only "true", "1", or "yes" as true. Replace direct `bool(os.getenv("DISABLE_QA_CACHE"))` checks in the cache helper functions with this utility.

### Tests
`ruff check .` *(fails: E401, F401 and others)*
`black --check .` *(fails: would reformat app/model_picker.py)*
`pytest -q` *(fails: multiple tests such as tests/test_ask_skills.py::test_keyword_catalog_shortcuts)*

### Risk
Low. The helper only affects interpretation of environment variables for QA cache control and defaults to `False` for unrecognized values.

------
https://chatgpt.com/codex/tasks/task_e_6893710d7c30832a99f64eb13f35f4f5