### PR TITLE
feat: add semantic intent detection

### DIFF
--- a/app/intent_detector.py
+++ b/app/intent_detector.py
@@ -1,34 +1,130 @@
-"""Simple heuristic intent detector."""
+"""Hybrid intent detector combining heuristics and a semantic classifier."""
 
-from .skills.smalltalk_skill import is_greeting
+from __future__ import annotations
+
+import os
+import re
+from functools import lru_cache
+from typing import Any, Dict, Iterable, Tuple
+
+from rapidfuzz import fuzz
+from sentence_transformers import SentenceTransformer, util
+
+from .telemetry import log_record_var
+
+# ---------------------------------------------------------------------------
+# Heuristic matchers
+# ---------------------------------------------------------------------------
+GREETINGS: Iterable[str] = {
+    "hi",
+    "hello",
+    "hey",
+    "yo",
+    "sup",
+    "good morning",
+    "good afternoon",
+    "good evening",
+}
+
+# Match a wider set of control phrases such as "turn on", "switch off",
+# "open the garage", etc.
+CONTROL_RE = re.compile(
+    r"\b(?:turn|switch|power|toggle|set)\s+(?:on|off|up|down)\b|"
+    r"\b(?:open|close|lock|unlock)\b",
+    re.IGNORECASE,
+)
+
+# Configurable threshold used for the semantic classifier
+DEFAULT_THRESHOLD: float = float(os.getenv("INTENT_THRESHOLD", "0.7"))
+
+# ---------------------------------------------------------------------------
+# Semantic classifier (SBERT)
+# ---------------------------------------------------------------------------
+MODEL_NAME = os.getenv("SBERT_MODEL", "sentence-transformers/paraphrase-MiniLM-L3-v2")
+
+EXAMPLE_INTENTS: Dict[str, list[str]] = {
+    "chat": ["tell me a joke", "what's the weather like?"],
+    "control": ["turn on the light", "switch off the fan"],
+    "smalltalk": ["hello", "hi there"],
+    "unknown": ["asdfgh", "lorem ipsum"],
+}
 
 
-def detect_intent(prompt: str) -> tuple[str, str]:
-    """Classify a user prompt into broad intent buckets.
+@lru_cache(maxsize=1)
+def _get_model() -> tuple[SentenceTransformer, Dict[str, Any]]:
+    """Return the SBERT model and prototype embeddings."""
+    model = SentenceTransformer(MODEL_NAME)
+    embeds = {
+        label: model.encode(texts, convert_to_tensor=True).mean(0)
+        for label, texts in EXAMPLE_INTENTS.items()
+    }
+    return model, embeds
 
-    The checks run in the following order:
 
-    1. **Greeting** – phrases like "hi" or "yo" short‑circuit to
-       ``("smalltalk", "low")``.
-    2. **Control** – commands containing "turn on"/"turn off" are treated as
-       high‑confidence automation requests and return
-       ``("control", "high")``.
-    3. **Chat** – prompts under ten words are considered casual chat and yield
-       ``("chat", "medium")``.
-    4. **Unknown** – anything else is labeled ``("unknown", "low")``.
+def _semantic_classify(text: str) -> Tuple[str, float]:
+    """Return ``(intent, score)`` using cosine similarity over prototypes."""
+    model, embeds = _get_model()
+    emb = model.encode(text, convert_to_tensor=True)
+    scores = {label: float(util.cos_sim(emb, proto)) for label, proto in embeds.items()}
+    intent, score = max(scores.items(), key=lambda kv: kv[1])
+    return intent, score
 
-    The function intentionally favors control phrases with high confidence so
-    they are executed before more ambiguous chat heuristics.
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def detect_intent(prompt: str, threshold: float = DEFAULT_THRESHOLD) -> tuple[str, str]:
+    """Classify *prompt* returning ``(intent_category, confidence)``.
+
+    Heuristics short‑circuit obvious greetings and control requests.  When these
+    fail, a lightweight SBERT classifier assigns the prompt to the closest
+    prototype intent.  ``threshold`` controls how confident the semantic match
+    must be to be considered a real intent; below that it is marked ``unknown``.
     """
 
-    prompt_lower = prompt.lower()
-    if is_greeting(prompt):
-        return "smalltalk", "low"
-    if any(kw in prompt_lower for kw in ("turn on", "turn off")):
-        return "control", "high"
-    parts = prompt_lower.split()
-    if len(parts) < 10:
-        if len(parts) == 1:
-            return "unknown", "low"
-        return "chat", "medium"
-    return "unknown", "low"
+    prompt_l = prompt.lower().strip()
+
+    # -- Greeting heuristic --------------------------------------------------
+    if any(fuzz.partial_ratio(prompt_l, g) >= 80 for g in GREETINGS):
+        score = 1.0
+        intent, level = "smalltalk", "low"
+        rec = log_record_var.get()
+        if rec:
+            rec.intent = intent
+            rec.intent_confidence = score
+        return intent, level
+
+    # -- Control heuristic ---------------------------------------------------
+    if CONTROL_RE.search(prompt_l):
+        score = 1.0
+        intent, level = "control", "high"
+        rec = log_record_var.get()
+        if rec:
+            rec.intent = intent
+            rec.intent_confidence = score
+        return intent, level
+
+    # Single-word prompts that aren't greetings are likely noise
+    if len(prompt_l.split()) == 1:
+        score = 0.0
+        intent, level = "unknown", "low"
+        rec = log_record_var.get()
+        if rec:
+            rec.intent = intent
+            rec.intent_confidence = score
+        return intent, level
+
+    # -- Semantic fallback ---------------------------------------------------
+    intent, score = _semantic_classify(prompt_l)
+    if score < threshold:
+        intent, level = "unknown", "low"
+    else:
+        level = "high" if score >= 0.9 else "medium"
+
+    rec = log_record_var.get()
+    if rec:
+        rec.intent = intent
+        rec.intent_confidence = float(score)
+    return intent, level

--- a/app/model_picker.py
+++ b/app/model_picker.py
@@ -15,6 +15,7 @@ HEAVY_TOKENS = int(os.getenv("MODEL_ROUTER_HEAVY_TOKENS", "1000"))
 KEYWORDS = {"code", "research", "analyze", "explain", "diagram", "summarize"}
 HEAVY_INTENTS = {"analysis", "research"}
 
+
 def pick_model(prompt: str, intent: str, tokens: int) -> Tuple[str, str]:
     """Route prompt to the best engine/model for the task."""
     prompt_lc = prompt.lower()

--- a/app/telemetry.py
+++ b/app/telemetry.py
@@ -36,6 +36,8 @@ class LogRecord(BaseModel):
     # routing / skills
     matched_skill: Optional[str] = None
     match_confidence: Optional[float] = None
+    intent: Optional[str] = None
+    intent_confidence: Optional[float] = None
 
     # llm usage
     model_name: Optional[str] = None

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,3 +24,5 @@ passlib[bcrypt]
 python-jose[cryptography]
 passlib
 pytest-asyncio
+sentence-transformers
+rapidfuzz

--- a/tests/test_intent_detector.py
+++ b/tests/test_intent_detector.py
@@ -11,6 +11,7 @@ from app.intent_detector import detect_intent
     "text, expected",
     [
         ("yo", ("smalltalk", "low")),
+        ("hello there", ("smalltalk", "low")),
         ("turn on the lights", ("control", "high")),
         ("tell me a fun fact", ("chat", "medium")),
         ("asdasdasd", ("unknown", "low")),


### PR DESCRIPTION
### Problem
Intent detection relied on simple regex heuristics, missing fuzzy greetings and lacking semantic fallback.

### Solution
- integrate rapidfuzz for fuzzy greeting detection
- add robust regex for control commands
- incorporate SBERT-based classifier with confidence threshold and logging
- record intent & score in LogRecord
- add dependencies and tests

### Tests
`PYENV_VERSION=3.12.10 black --check .`
`PYENV_VERSION=3.12.10 ruff check .` *(fails: numerous existing lint errors)*
`PYENV_VERSION=3.12.10 pytest tests/test_intent_detector.py -q` *(fails: numpy module attribute error)*

### Risk
SBERT model loading and heavy dependencies may affect startup time; further optimizations or model caching may be required.

------
https://chatgpt.com/codex/tasks/task_e_689374b028dc832aaf58d8f2ab0c2fae