### PR TITLE
Add configurable LLaMA smoke test script

### DIFF
--- a/scripts/smoke_llama.sh
+++ b/scripts/smoke_llama.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Simple health check for Ollama's LLaMA endpoint.
+# Uses POST /api/generate instead of /api/ping.
+# Exit codes: 0 = healthy, 1 = unhealthy.
+
+HOST="${OLLAMA_URL:-http://localhost:11434}"
+MODEL="${OLLAMA_MODEL:-llama3}"
+# Override defaults via OLLAMA_URL/OLLAMA_MODEL or -H/-M flags.
+
+while getopts "H:M:" opt; do
+  case "$opt" in
+    H) HOST="$OPTARG" ;;
+    M) MODEL="$OPTARG" ;;
+  esac
+done
+
+# Make request; capture HTTP status code.
+STATUS=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$HOST/api/generate" \
+  -H 'Content-Type: application/json' \
+  -d "{\"model\":\"$MODEL\",\"prompt\":\"hi\"}") || STATUS=000
+
+if [ "$STATUS" -eq 200 ]; then
+  exit 0
+else
+  exit 1
+fi


### PR DESCRIPTION
### Problem
Previous LLaMA smoke check hit `/api/ping` and baked in host/model values.

### Solution
- Added `scripts/smoke_llama.sh` using `POST /api/generate` for health checks.
- Host and model can be overridden with `OLLAMA_URL`/`OLLAMA_MODEL` or `-H`/`-M` flags.
- Returns `0` for healthy and `1` for unhealthy states.

### Tests
`python3 -m pytest -q` *(fails: ModuleNotFoundError: fastapi)*
`python3 -m ruff check .` *(fails: numerous lint errors)*
`python3 -m black --check .` *(fails: would reformat app/memory/vector_store.py)*

### Risk
Low – new optional script.

------
https://chatgpt.com/codex/tasks/task_e_6893e93f552c832a97a4390960cc3cc2