### PR TITLE
Add LLaMA metrics

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -142,6 +142,8 @@ except Exception:  # pragma: no cover - executed when dependency missing
                     f"{metrics.REQUEST_COUNT.name} {metrics.REQUEST_COUNT.value}",
                     f"{metrics.REQUEST_LATENCY.name} {metrics.REQUEST_LATENCY.value}",
                     f"{metrics.REQUEST_COST.name} {metrics.REQUEST_COST.value}",
+                    f"{metrics.LLAMA_TOKENS.name} {metrics.LLAMA_TOKENS.value}",
+                    f"{metrics.LLAMA_LATENCY.name} {metrics.LLAMA_LATENCY.value}",
                 ]
                 body = ("\n".join(parts) + "\n").encode()
             except Exception:

--- a/app/metrics.py
+++ b/app/metrics.py
@@ -36,3 +36,12 @@ REQUEST_COST = Histogram(
     "Request cost in USD",
     ["endpoint", "method", "engine"],
 )
+
+# Counter for LLaMA prompt/completion tokens
+LLAMA_TOKENS = Counter("llama_tokens", "Number of LLaMA tokens", ["direction"])
+
+# Histogram for LLaMA call latency in milliseconds
+LLAMA_LATENCY = Histogram(
+    "llama_latency_ms",
+    "Latency of LLaMA generations in milliseconds",
+)

--- a/tests/test_llama_metrics.py
+++ b/tests/test_llama_metrics.py
@@ -1,0 +1,86 @@
+import asyncio
+
+from app import llama_integration
+
+
+class FakeCounter:
+    def __init__(self):
+        self.counts = {}
+
+    def labels(self, **labels):
+        direction = labels.get("direction")
+        self.counts.setdefault(direction, 0)
+        parent = self
+
+        class Child:
+            def inc(self, amount=1.0):
+                parent.counts[direction] += amount
+
+        return Child()
+
+
+class FakeHistogram:
+    def __init__(self):
+        self.values = []
+
+    def labels(self, **labels):
+        return self
+
+    def observe(self, amount):
+        self.values.append(amount)
+
+
+class FakeStream:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+    def raise_for_status(self):
+        pass
+
+    async def aiter_lines(self):
+        yield '{"response":"hi"}'
+        yield '{"response":" there", "done": true}'
+
+
+class FakeClient:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+    def stream(self, method, url, json):
+        return FakeStream()
+
+
+def test_llama_metrics(monkeypatch):
+    monkeypatch.setenv("OLLAMA_URL", "http://x")
+    monkeypatch.setenv("OLLAMA_MODEL", "llama3")
+    llama_integration.OLLAMA_URL = "http://x"
+    llama_integration.OLLAMA_MODEL = "llama3"
+
+    tokens = FakeCounter()
+    latency = FakeHistogram()
+    monkeypatch.setattr(llama_integration, "LLAMA_TOKENS", tokens)
+    monkeypatch.setattr(llama_integration, "LLAMA_LATENCY", latency)
+    monkeypatch.setattr(
+        llama_integration,
+        "httpx",
+        type("x", (), {"AsyncClient": lambda *a, **k: FakeClient()}),
+    )
+
+    async def run():
+        out = []
+        async for tok in llama_integration.ask_llama("hello world"):
+            out.append(tok)
+        return out
+
+    result = asyncio.run(run())
+    assert "".join(result) == "hi there"
+    assert tokens.counts["prompt"] == 2
+    assert tokens.counts["completion"] == 2
+    assert len(latency.values) == 1
+    assert latency.values[0] >= 0


### PR DESCRIPTION
### Problem
LLaMA integration lacked dedicated metrics for token usage and latency.

### Solution
- Introduced `llama_tokens` counter and `llama_latency_ms` histogram.
- Instrumented `ask_llama` to time calls and count prompt/completion tokens.
- Exposed metrics via `/metrics` endpoint fallback.
- Added test for LLaMA metrics.

### Tests
`PYENV_VERSION=3.10.17 ruff check app/metrics.py app/main.py app/llama_integration.py tests/test_llama_metrics.py`
`PYENV_VERSION=3.10.17 black --check app/metrics.py app/main.py app/llama_integration.py tests/test_llama_metrics.py`
`PYENV_VERSION=3.10.17 pytest tests/test_llama_metrics.py -q`
`curl -sL http://127.0.0.1:8000/metrics | grep llama_tokens -n`
`curl -sL http://127.0.0.1:8000/metrics | grep llama_latency_ms -n | head -n 5`

### Risk
Low. Metrics default to no-ops if Prometheus client is unavailable.

------
https://chatgpt.com/codex/tasks/task_e_6893e8f2a4e8832a8f1e4de7da48cd69