### PR TITLE
feat: add AsyncOpenAI fallback stub

### DIFF
--- a/app/gpt_client.py
+++ b/app/gpt_client.py
@@ -19,6 +19,17 @@ import os
 import time
 from collections.abc import Awaitable, Callable
 
+try:  # pragma: no cover - exercised indirectly
+    from openai import AsyncOpenAI
+except Exception:  # pragma: no cover - import-time guard
+
+    class AsyncOpenAI:  # type: ignore
+        """Fallback stub when ``openai`` isn't installed."""
+
+        def __init__(self, *args, **kwargs) -> None:
+            raise RuntimeError("openai package not installed")
+
+
 from .metrics import REQUEST_COST, REQUEST_COUNT, REQUEST_LATENCY
 from .telemetry import log_record_var
 
@@ -39,24 +50,19 @@ MODEL_PRICING = {
 }
 
 
-def get_client() -> "AsyncOpenAI":
+def get_client() -> AsyncOpenAI:
     """Return a singleton ``AsyncOpenAI`` client.
 
     The API key is fetched at call time so tests can monkeypatch the
     environment. If the key is missing a ``RuntimeError`` is raised.
     """
     global _client
-    try:
-        from openai import AsyncOpenAI
-    except ImportError:
-        raise RuntimeError("openai package not installed")
     if _client is None:
         api_key = os.getenv("OPENAI_API_KEY")
         if not api_key:
             raise RuntimeError("OPENAI_API_KEY not set")
         _client = AsyncOpenAI(api_key=api_key)
     return _client
-
 
 
 async def close_client() -> None:


### PR DESCRIPTION
### Problem
Using `openai` in `gpt_client` caused import errors when the dependency isn't installed, preventing module load and breaking `_client` annotations.

### Solution
- Add a module-level `try`/`except` importing `AsyncOpenAI` and fallback stub class.
- Annotate `_client` with the imported/stubbed `AsyncOpenAI` and use it in `get_client` without re-importing.

### Tests
`pytest -q` *(fails: No module named 'pytest_asyncio')*
`ruff check .` *(fails: Multiple lint errors in repository)*
`black --check .` *(fails: llama_integration.py would be reformatted)*

### Risk
Low. Changes are isolated to `gpt_client` and only affect OpenAI client handling when the dependency is absent.

------
https://chatgpt.com/codex/tasks/task_e_68941c352458832aa5e13ed0a8dae4d4