### PR TITLE
Ensure Chroma client has data directory

### DIFF
--- a/app/memory/vector_store.py
+++ b/app/memory/vector_store.py
@@ -8,7 +8,7 @@ Environment flags:
 - `VECTOR_STORE`: `memory`/`inmemory` to force test store, else uses Chroma.
 - `SIM_THRESHOLD`: cosine similarity threshold (default 0.90).
 - `DISABLE_QA_CACHE`: truthy value disables all QA‑cache operations.
-- `CHROMA_PATH`: filesystem path for Chroma DB (default `.chromadb`).
+- `CHROMA_PATH`: filesystem path for Chroma DB (default `.chroma_data`).
 """
 
 from __future__ import annotations
@@ -252,7 +252,8 @@ class MemoryVectorStore(VectorStore):
 class ChromaVectorStore(VectorStore):
     def __init__(self) -> None:
         self._dist_cutoff = 1.0 - float(os.getenv("SIM_THRESHOLD", "0.90"))
-        path = os.getenv("CHROMA_PATH", ".chromadb")
+        path = os.getenv("CHROMA_PATH", ".chroma_data")
+        os.makedirs(path, exist_ok=True)
         self._client = chromadb.PersistentClient(path=path)
         self._embedder = _LengthEmbedder()
         self._cache = self._client.get_or_create_collection(


### PR DESCRIPTION
### Problem
ChromaVectorStore failed if the specified database directory didn't exist, causing `sqlite3.OperationalError` during startup.

### Solution
Resolve path via `CHROMA_PATH` (default `.chroma_data`), create the directory with `os.makedirs`, then initialize `chromadb.PersistentClient`.

### Tests
`pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi', etc.)*
`ruff check .` *(fails: multiple lint errors)*
`black --check .` *(fails: would reformat 2 files)*

### Risk
Low. Directory creation is idempotent and only affects Chroma initialization.

------
https://chatgpt.com/codex/tasks/task_e_68941c409500832a97dc1618913a1c63