### PR TITLE
Default to MemoryVectorStore during tests

### DIFF
--- a/app/memory/vector_store.py
+++ b/app/memory/vector_store.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import hashlib
 import os
+import sys
 import time
 import unicodedata
 import uuid
@@ -343,11 +344,12 @@ class ChromaVectorStore(VectorStore):
 
 
 def _get_store() -> VectorStore:
-    return (
-        MemoryVectorStore()
-        if os.getenv("VECTOR_STORE", "").lower() in ("memory", "inmemory")
-        else ChromaVectorStore()
-    )
+    kind = os.getenv("VECTOR_STORE", "").lower()
+    if kind in ("memory", "inmemory"):
+        return MemoryVectorStore()
+    if "PYTEST_CURRENT_TEST" in os.environ or "pytest" in sys.modules:
+        return MemoryVectorStore()
+    return ChromaVectorStore()
 
 
 _store: VectorStore = _get_store()

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -242,7 +242,6 @@ def test_llama_circuit_open(monkeypatch):
     os.environ["OLLAMA_MODEL"] = "llama3"
     os.environ["HOME_ASSISTANT_URL"] = "http://ha"
     os.environ["HOME_ASSISTANT_TOKEN"] = "token"
-    os.environ["VECTOR_STORE"] = "memory"
     from app import router
 
     monkeypatch.setattr(router, "llama_circuit_open", True)
@@ -257,7 +256,6 @@ def test_generation_options_passthrough(monkeypatch):
     os.environ["OLLAMA_MODEL"] = "llama3"
     os.environ["HOME_ASSISTANT_URL"] = "http://ha"
     os.environ["HOME_ASSISTANT_TOKEN"] = "token"
-    os.environ["VECTOR_STORE"] = "memory"
     from app import router
 
     monkeypatch.setattr(router, "llama_circuit_open", False)


### PR DESCRIPTION
### Problem
Tests previously had to set `VECTOR_STORE=memory` manually to avoid hitting the Chroma backend during unit tests.

### Solution
- Detect Pytest and default the vector store to `MemoryVectorStore` when no `VECTOR_STORE` is configured.
- Removed explicit `VECTOR_STORE` assignments from router tests.

### Tests
`PYENV_VERSION=3.11.12 pytest tests/test_router.py::test_llama_circuit_open -q`
`PYENV_VERSION=3.11.12 pytest -q` *(fails: NameError: AsyncOpenAI; ModuleNotFoundError: jose, aiosqlite)*
`PYENV_VERSION=3.11.12 ruff check .` *(fails: E401 and others)*
`PYENV_VERSION=3.11.12 black --check .` *(fails: would reformat files)*

### Risk
Low: Only activates memory store when Pytest is present; production behavior unchanged.

------
https://chatgpt.com/codex/tasks/task_e_68941c471a50832ab17518461b1f08fa