### PR TITLE
Add return type annotation for ChromaVectorStore.qa_cache

### DIFF
--- a/app/memory/vector_store.py
+++ b/app/memory/vector_store.py
@@ -19,11 +19,14 @@ import time
 import unicodedata
 import uuid
 from dataclasses import dataclass
-from typing import Dict, List, Optional, Sequence, Tuple
+from typing import TYPE_CHECKING, Dict, List, Optional, Sequence, Tuple
 
 import numpy as np
 import chromadb
 from app.embeddings import embed_sync
+
+if TYPE_CHECKING:  # pragma: no cover - used only for type hints
+    from chromadb.api.models.Collection import Collection as ChromaCollection
 
 # ---------------------------------------------------------------------------
 # Environment helpers
@@ -291,7 +294,7 @@ class ChromaVectorStore(VectorStore):
         return [doc for _, _, doc in items[:k]]
 
     @property
-    def qa_cache(self):
+    def qa_cache(self) -> "ChromaCollection":
         return self._cache
 
     def cache_answer(self, cache_id: str, prompt: str, answer: str) -> None:


### PR DESCRIPTION
### Problem
Missing return type annotation for `ChromaVectorStore.qa_cache` led to inconsistent interface coverage.

### Solution
- Annotated `qa_cache` property with the `ChromaCollection` return type.
- Added `TYPE_CHECKING` import for the type hint.

### Tests
`pytest -q` *(fails: ModuleNotFoundError: No module named 'jose')*
`ruff check .` *(fails: app/alias_store.py:2:1: E401 Multiple imports on one line)*
`black --check .` *(fails: would reformat /workspace/GesahniV2/app/gpt_client.py)*

### Risk
Low. Changes are limited to typing annotations in the vector store.

------
https://chatgpt.com/codex/tasks/task_e_68941c94eef4832a82763f506c3c31e3