### PR TITLE
test: isolate chroma path

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,8 +1,15 @@
 import os
 import sys
+import shutil
+import tempfile
 
 # Ensure asynchronous tests have an event loop available and JWT auth works.
 os.environ.setdefault("JWT_SECRET", "secret")
+
+# Use an isolated temporary directory for any on-disk Chroma data during tests
+_prev_chroma = os.environ.get("CHROMA_PATH")
+_tmp_chroma = tempfile.mkdtemp(prefix="chroma_test_")
+os.environ["CHROMA_PATH"] = _tmp_chroma
 
 
 def _ensure_openai_error() -> None:
@@ -30,3 +37,11 @@ def pytest_collect_file(file_path, path, parent):  # pragma: no cover - hook
 
 
 pytest_plugins = ("pytest_asyncio",)
+
+
+def pytest_sessionfinish(session, exitstatus):  # pragma: no cover - cleanup hook
+    shutil.rmtree(_tmp_chroma, ignore_errors=True)
+    if _prev_chroma is not None:
+        os.environ["CHROMA_PATH"] = _prev_chroma
+    else:
+        os.environ.pop("CHROMA_PATH", None)


### PR DESCRIPTION
### Problem
Tests were writing Chroma data to a persistent directory, leaving artifacts on disk and risking cross-test interference.

### Solution
Use a temporary directory for `CHROMA_PATH` during tests and clean it up when the test session finishes.

### Tests
`PYENV_VERSION=3.11.12 ruff check .` *(fails: multiple lint errors)*

`PYENV_VERSION=3.11.12 black --check .` *(fails: would reformat 2 files)*

`PYENV_VERSION=3.11.12 pytest -q` *(fails: missing dependencies such as pydantic, httpx, fastapi, numpy)*

### Risk
Low. Changes are isolated to test setup and use standard library utilities.


------
https://chatgpt.com/codex/tasks/task_e_68941c5599b0832a80eb9553474a2445