### PR TITLE
Ensure memory store fallback when CHROMA_PATH misconfigured

### DIFF
--- a/app/memory/vector_store.py
+++ b/app/memory/vector_store.py
@@ -343,11 +343,20 @@ class ChromaVectorStore(VectorStore):
 
 
 def _get_store() -> VectorStore:
-    return (
-        MemoryVectorStore()
-        if os.getenv("VECTOR_STORE", "").lower() in ("memory", "inmemory")
-        else ChromaVectorStore()
-    )
+    """Return the configured vector store.
+
+    ``ChromaVectorStore`` is the default backend.  If configuration or
+    initialization fails (for example, an invalid ``CHROMA_PATH``), the call
+    transparently falls back to the in-memory implementation so that imports do
+    not raise during tests or misconfigured environments.
+    """
+
+    if os.getenv("VECTOR_STORE", "").lower() in ("memory", "inmemory"):
+        return MemoryVectorStore()
+    try:
+        return ChromaVectorStore()
+    except Exception:  # pragma: no cover - best effort fallback
+        return MemoryVectorStore()
 
 
 _store: VectorStore = _get_store()

--- a/tests/test_vector_store_fallback.py
+++ b/tests/test_vector_store_fallback.py
@@ -1,0 +1,26 @@
+import importlib
+
+from app.memory import vector_store
+
+
+def test_get_store_falls_back_to_memory(monkeypatch, tmp_path):
+    # create a file path that cannot be used as a directory
+    bad_file = tmp_path / "not_a_dir"
+    bad_file.write_text("x")
+    monkeypatch.setenv("CHROMA_PATH", str(bad_file))
+    # Ensure default vector store path attempts chroma
+    monkeypatch.delenv("VECTOR_STORE", raising=False)
+
+    # Reload the module so _get_store uses the new CHROMA_PATH
+    module = importlib.reload(vector_store)
+
+    # Stub out embedding to avoid external dependencies during the test
+    monkeypatch.setattr(module, "embed_sync", lambda text: [0.0])
+
+    store = module._get_store()
+    assert isinstance(store, module.MemoryVectorStore)
+    store._dist_cutoff = 1.0
+
+    # Ensure basic operations work without raising
+    store.add_user_memory("u", "hello")
+    assert store.query_user_memories("u", "hello") == ["hello"]


### PR DESCRIPTION
### Problem
Chroma path misconfiguration could raise during import, preventing a fallback to the in-memory store.

### Solution
- Guard `_get_store()` with a try/except to fall back to `MemoryVectorStore` when `ChromaVectorStore` initialization fails.
- Add a regression test that simulates an invalid `CHROMA_PATH` and verifies the fallback.

### Tests
`PYENV_VERSION=3.11.12 pytest tests/test_vector_store_fallback.py -q`
`PYENV_VERSION=3.11.12 ruff check tests/test_vector_store_fallback.py`
`PYENV_VERSION=3.11.12 black --check tests/test_vector_store_fallback.py app/memory/vector_store.py`

### Risk
Low. The change only impacts vector-store initialization and introduces a graceful fallback.

------
https://chatgpt.com/codex/tasks/task_e_68941c4c1fdc832aa7add909fec0a2d1