### PR TITLE
Clamp SIM_THRESHOLD and warn

### DIFF
--- a/app/memory/vector_store.py
+++ b/app/memory/vector_store.py
@@ -14,6 +14,7 @@ Environment flags:
 from __future__ import annotations
 
 import hashlib
+import logging
 import os
 import time
 import unicodedata
@@ -25,6 +26,8 @@ import numpy as np
 import chromadb
 from app.embeddings import embed_sync
 
+logger = logging.getLogger(__name__)
+
 # ---------------------------------------------------------------------------
 # Environment helpers
 # ---------------------------------------------------------------------------
@@ -32,6 +35,30 @@ from app.embeddings import embed_sync
 
 def _env_flag(name: str) -> bool:
     return os.getenv(name, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+DEFAULT_SIM_THRESHOLD = 0.90
+
+
+def _get_sim_threshold() -> float:
+    raw = os.getenv("SIM_THRESHOLD", str(DEFAULT_SIM_THRESHOLD))
+    try:
+        value = float(raw)
+    except ValueError:
+        logger.warning(
+            "Invalid SIM_THRESHOLD %r; falling back to %.2f",
+            raw,
+            DEFAULT_SIM_THRESHOLD,
+        )
+        return DEFAULT_SIM_THRESHOLD
+    if not 0.0 <= value <= 1.0:
+        logger.warning(
+            "SIM_THRESHOLD %.2f out of range [0, 1]; falling back to %.2f",
+            value,
+            DEFAULT_SIM_THRESHOLD,
+        )
+        return DEFAULT_SIM_THRESHOLD
+    return value
 
 
 # ---------------------------------------------------------------------------
@@ -176,7 +203,7 @@ class VectorStore:
 
 class MemoryVectorStore(VectorStore):
     def __init__(self) -> None:
-        self._dist_cutoff = 1.0 - float(os.getenv("SIM_THRESHOLD", "0.90"))
+        self._dist_cutoff = 1.0 - _get_sim_threshold()
         self._cache = _Collection()
         self._user_memories: Dict[str, List[Tuple[str, str, List[float], float]]] = {}
 
@@ -251,7 +278,7 @@ class MemoryVectorStore(VectorStore):
 
 class ChromaVectorStore(VectorStore):
     def __init__(self) -> None:
-        self._dist_cutoff = 1.0 - float(os.getenv("SIM_THRESHOLD", "0.90"))
+        self._dist_cutoff = 1.0 - _get_sim_threshold()
         path = os.getenv("CHROMA_PATH", ".chromadb")
         self._client = chromadb.PersistentClient(path=path)
         self._embedder = _LengthEmbedder()

--- a/tests/test_vector_store_threshold.py
+++ b/tests/test_vector_store_threshold.py
@@ -15,3 +15,11 @@ def test_cache_hit_low_threshold(monkeypatch):
     store.cache_answer("1", "hello", "world")
     # Cutoff 1.0 -> distance 1.0 still considered a hit
     assert store.lookup_cached_answer("helloo") == "world"
+
+
+def test_threshold_out_of_range(monkeypatch, caplog):
+    monkeypatch.setenv("SIM_THRESHOLD", "5")
+    with caplog.at_level("WARNING"):
+        store = ChromaVectorStore()
+    assert store._dist_cutoff == 1.0 - 0.90
+    assert "SIM_THRESHOLD" in caplog.text


### PR DESCRIPTION
### Problem
`SIM_THRESHOLD` could be set outside a reasonable range leading to invalid distance cutoffs.

### Solution
- Add `_get_sim_threshold` helper that validates `SIM_THRESHOLD` and falls back to a default when out of range.
- Use the helper in both vector store backends.
- Log warnings when values are invalid and add a regression test.

### Tests
`pytest tests/test_vector_store_threshold.py -q` *(fails: No module named 'chromadb')*
`ruff check .` *(fails: multiple style violations)*
`black --check .` *(fails: would reformat app/gpt_client.py, app/llama_integration.py)*

### Risk
Low. Change is localized to vector store initialization; default behavior retained when env var is invalid.

------
https://chatgpt.com/codex/tasks/task_e_68941c6fdb5c832ab6887f5928211579