### PR TITLE
Rename memory vector store class

### DIFF
--- a/app/memory/vector_store.py
+++ b/app/memory/vector_store.py
@@ -230,11 +230,11 @@ class VectorStore:
 
 
 # ---------------------------------------------------------------------------
-# ChromaVectorStore
+# MemoryVectorStore
 # ---------------------------------------------------------------------------
 
 
-class ChromaVectorStore(VectorStore):
+class MemoryVectorStore(VectorStore):
     def __init__(self) -> None:
         self._dist_cutoff = 1.0 - _get_sim_threshold()
         self._cache = _Collection()


### PR DESCRIPTION
### Problem
Memory backend class was misnamed `ChromaVectorStore`, which caused confusion with the actual Chroma-backed implementation.

### Solution
- Rename the in-memory implementation to `MemoryVectorStore`.
- Confirm factory and `__all__` export reference the new class name.

### Tests
`python3 -m pytest tests/test_memory_env.py::test_default_env_memory -q` *(fails: ModuleNotFoundError: No module named 'numpy')*
`ruff check app/memory/vector_store.py` *(fails: F811, F821)*
`black --check app/memory/vector_store.py` *(fails: would reformat file)*

### Risk
Low. Changes are limited to class naming; functionality unchanged.

------
https://chatgpt.com/codex/tasks/task_e_68942d133df0832a9514fddd97c489b6