### PR TITLE
Handle empty feedback metadata

### DIFF
--- a/app/memory/vector_store.py
+++ b/app/memory/vector_store.py
@@ -378,10 +378,12 @@ class ChromaVectorStore(VectorStore):
         if _env_flag("DISABLE_QA_CACHE"):
             return
         _, norm = _normalize(prompt)
+        raw_meta = {"answer": answer, "timestamp": time.time(), "feedback": None}
+        cleaned = _clean_meta(raw_meta)
         self._cache.upsert(
             ids=[cache_id],
             documents=[norm],
-            metadatas=[{"answer": answer, "timestamp": time.time(), "feedback": None}],
+            metadatas=[cleaned],
         )
 
     def lookup_cached_answer(

--- a/tests/test_cache_none_feedback.py
+++ b/tests/test_cache_none_feedback.py
@@ -1,0 +1,24 @@
+import pytest
+from app.memory.vector_store import ChromaVectorStore
+
+
+@pytest.fixture
+def store():
+    s = ChromaVectorStore()
+    yield s
+    s.close()
+
+
+def test_cache_allows_none_feedback(monkeypatch, store):
+    # Wrap the underlying upsert to ensure metadata values are cleaned of None
+    original_upsert = store._cache.upsert
+
+    def wrapped_upsert(*args, **kwargs):
+        meta = kwargs["metadatas"][0]
+        assert None not in meta.values()
+        return original_upsert(*args, **kwargs)
+
+    monkeypatch.setattr(store._cache, "upsert", wrapped_upsert)
+
+    store.cache_answer("1", "hello", "world")
+    assert store.lookup_cached_answer("hello") == "world"


### PR DESCRIPTION
### Problem
Chroma upserts fail when metadata contains `None` values, causing the QA cache to break when feedback is unset.

### Solution
Wrap QA cache metadata with `_clean_meta` to strip `None` values and add a regression test ensuring caching succeeds when feedback is `None`.

### Tests
`PYENV_VERSION=3.11.12 pytest -q` *(fails: ModuleNotFoundError: No module named 'rapidfuzz')*
`PYENV_VERSION=3.11.12 ruff check .` *(fails: Found 86 errors)*
`PYENV_VERSION=3.11.12 black --check .` *(fails: 5 files would be reformatted)*

### Risk
Low: changes are limited to QA cache metadata sanitization and accompanying tests.

------
https://chatgpt.com/codex/tasks/task_e_68942d14a404832a943fc49ec66706b9