### PR TITLE
Expose QA cache accessor

### DIFF
--- a/app/memory/vector_store.py
+++ b/app/memory/vector_store.py
@@ -514,6 +514,11 @@ def record_feedback(prompt: str, feedback: str) -> None:
     return _store.record_feedback(prompt, feedback)
 
 
+def qa_cache():
+    """Return the underlying QA cache collection."""
+    return _store.qa_cache
+
+
 def invalidate_cache(prompt: str) -> None:
     cid = _normalized_hash(prompt)
     logger.debug("Invalidating cache for %s", cid)
@@ -537,6 +542,7 @@ __all__ = [
     "cache_answer_legacy",
     "lookup_cached_answer",
     "record_feedback",
+    "qa_cache",
     "invalidate_cache",
     "close_store",
     "VectorStore",


### PR DESCRIPTION
### Problem
`vector_store` did not expose its underlying QA cache, making it difficult for tests and callers to inspect or manipulate cached entries.

### Solution
Add a module-level `qa_cache` accessor that returns the active store's QA cache and export it via `__all__` for direct access.

### Tests
`PYENV_VERSION=3.11.12 python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'aiofiles', etc.)*

`PYENV_VERSION=3.11.12 ruff check .` *(fails: multiple lint errors, undefined names)*

`PYENV_VERSION=3.11.12 black --check .` *(fails: would reformat several files)*

### Risk
Low. The change only exposes an existing object without altering functionality.

------
https://chatgpt.com/codex/tasks/task_e_68942d154988832aafabb963191dff58