### PR TITLE
Refactor vector_store imports and logger

### DIFF
--- a/app/memory/vector_store.py
+++ b/app/memory/vector_store.py
@@ -20,13 +20,11 @@ import sys
 import time
 import unicodedata
 import uuid
-import logging
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Dict, List, Optional, Sequence, Tuple
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Tuple
 
 import numpy as np
-import chromadb
-import logging
+
 try:  # pragma: no cover - optional dependency
     import chromadb
 except ImportError:  # pragma: no cover - optional dependency
@@ -38,14 +36,8 @@ from app.telemetry import hash_user_id
 
 logger = logging.getLogger(__name__)
 
-logger = logging.getLogger(__name__)
-
 if TYPE_CHECKING:  # pragma: no cover - used only for type hints
     from chromadb.api.models.Collection import Collection as ChromaCollection
-
-logger = logging.getLogger(__name__)
-
-logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Environment helpers
@@ -128,14 +120,6 @@ class _LengthEmbedder:
     def name(self) -> str:  # pragma: no cover - simple helper for Chroma
         """Return a stable name used by Chroma to identify the embedder."""
         return "length-embedder"
-
-
-# ---------------------------------------------------------------------------
-# Logger
-# ---------------------------------------------------------------------------
-
-
-logger = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
### Problem
`app/memory/vector_store.py` contained multiple duplicated `logging` and `chromadb` imports and repeated logger declarations, which added unnecessary clutter.

### Solution
Removed redundant import statements and ensured only one `logger = logging.getLogger(__name__)` declaration remains.

### Tests
`pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*
`ruff check .` *(fails: Found 82 errors)*
`black --check .` *(fails: would reformat 5 files)*

### Risk
Low risk; changes are limited to removing redundant imports and logger setup.

------
https://chatgpt.com/codex/tasks/task_e_68942d18e6e4832a820158b08cf1c08e