### PR TITLE
chore: add chat logging

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -43,7 +43,9 @@ export default function Page() {
   }, [messages]);
 
   const handleSend = async (text: string) => {
+    console.log('handleSend invoked');
     if (!text.trim()) return;
+    console.log('Outgoing prompt:', text);
 
     // Optimistically render the user message
     setMessages(prev => [...prev, { role: 'user', content: text }]);
@@ -52,6 +54,7 @@ export default function Page() {
     try {
       // 🔗 Use the shared helper so we always hit NEXT_PUBLIC_API_URL
       const replyText = await sendPrompt(text, model);
+      console.log('Response received:', replyText);
       setMessages(prev => [...prev, { role: 'assistant', content: replyText }]);
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
### Problem
handleSend offered no visibility into requests and responses.

### Solution
Log handleSend invocation, outgoing prompts, and the arrival of responses.

### Tests
`PYENV_VERSION=3.11.12 python -m pytest -q` *(missing fastapi, pydantic, httpx, numpy, etc.)*
`PYENV_VERSION=3.11.12 ruff check .`
`PYENV_VERSION=3.11.12 black --check .`

### Risk
Low; change only adds client-side console logging.

------
https://chatgpt.com/codex/tasks/task_e_689456bfc3c4832ab9dcfca7b43aac7f