### PR TITLE
feat: await send handler

### DIFF
--- a/frontend/src/components/InputBar.tsx
+++ b/frontend/src/components/InputBar.tsx
@@ -10,7 +10,7 @@ export default function InputBar({
   model,
   onModelChange,
 }: {
-  onSend: (text: string) => void;
+  onSend: (text: string) => Promise<void> | void;
   loading: boolean;
   model: string;
   onModelChange: (m: string) => void;
@@ -20,13 +20,21 @@ export default function InputBar({
   const handleKey = (e: KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.key === "Enter" && !e.shiftKey) {
       e.preventDefault();
-      send();
+      void send();
     }
   };
 
-  const send = () => {
-    onSend(text);
-    setText("");
+  const send = async () => {
+    const trimmed = text.trim();
+    if (!trimmed) return;
+
+    try {
+      await onSend(trimmed);
+      setText("");
+    } catch (err) {
+      // Keep input if send fails
+      console.error(err);
+    }
   };
 
   return (
@@ -48,7 +56,7 @@ export default function InputBar({
         rows={1}
         disabled={loading}
       />
-      <Button onClick={send} disabled={loading || !text.trim()} size="icon">
+      <Button onClick={() => { void send(); }} disabled={loading || !text.trim()} size="icon">
         <Send className="size-4" />
       </Button>
     </div>


### PR DESCRIPTION
### Problem
`send()` in the input bar would send blank messages and clear the textbox even if the send handler failed.

### Solution
Trim the input before sending, await the `onSend` handler, and only clear the textbox after a successful send.

### Tests
`pytest -q` *(fails: openai package not installed, config assertion)*
`ruff check .` *(fails: lint errors)*
`black --check .` *(fails: files would be reformatted)*

### Risk
Low. Changes are limited to the client-side input component.

------
https://chatgpt.com/codex/tasks/task_e_689456d479b8832a84b76cf68458aed3