### PR TITLE
fix frontend model override

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,14 +1,17 @@
 const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
 
-export async function sendPrompt(prompt: string, model: string): Promise<string> {
-  const url = `${API_URL}/ask`;
+export async function sendPrompt(
+  prompt: string,
+  modelOverride: string,
+): Promise<string> {
+  const url = `${API_URL}/v1/ask`;
   console.debug('API_URL baked into bundle:', API_URL);
   console.debug('Sending request to', url);
 
   const res = await fetch(url, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ prompt, model })
+    body: JSON.stringify({ prompt, model_override: modelOverride })
   });
 
   console.debug('Received response', res.status, res.statusText);


### PR DESCRIPTION
### Problem
Model overrides from the web UI were posted to `/ask` with a `model` field, bypassing versioned routing and failing to trigger LLaMA.

### Solution
- Update `sendPrompt` to hit `/v1/ask` and send `model_override`.

### Tests
`python3 -m pytest tests/test_intent_detector.py::test_detect_intent_cases --maxfail=1 -q` (fails: expected medium)
`ruff check .` (fails: lint errors)
`black --check .` (fails: would reformat files)

### Risk
Low—client-side change only. Backend routing already handled overrides.

------
https://chatgpt.com/codex/tasks/task_e_68945b03d118832aad3bf66814d6c182