### PR TITLE
docs: clarify story-mode roadmap

### DIFF
--- a/updates.md
+++ b/updates.md
@@ -4,7 +4,7 @@
 
 | Section                    | Key Decisions                                                                                                                                                                                                           | Why We Chose It                                                                                                                         | Cost Notes                                                                              |
 | -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
-| **Capture Strategy**       | • **Realtime Audio STT** (`gpt-4o-mini-transcribe`) to grab every word live.<br>• **Full‑duplex “Assistant” feel** → turn on TTS replies only in Story Mode.                                                            | • Feels like a natural convo (bot can clarify in the moment).<br>• Boosts transcript quality with instant follow‑ups (“Which cousin?”). | • STT \$0.006/min.<br>• TTS \$0.015/min.<br>• Total ≈ \$0.021–\$0.023/min with both on. |
+| **Capture Strategy**       | • **Realtime Audio STT** (`whisper-1`) to grab every word live.<br>• **Full‑duplex “Assistant” feel** → turn on TTS replies only in Story Mode.                                                            | • Feels like a natural convo (bot can clarify in the moment).<br>• Boosts transcript quality with instant follow‑ups (“Which cousin?”). | • STT \$0.006/min.<br>• TTS \$0.015/min.<br>• Total ≈ \$0.021–\$0.023/min with both on. |
 | **Everyday Assistant**     | Keep current **Chat Completions** flow (HTTP) with cheap models (`gpt-3.5-turbo` or local LLaMA) for lights, timers, FAQs.                                                                                              | • Lowest cost for day‑to‑day.<br>• No audio overhead unless user explicitly speaks.                                                     | Same as today (fractions of a cent per 1K tokens).                                      |
 | **Storage & Metadata**     | • Save raw transcript JSONL per session.<br>• Tag speaker, timestamps, confidence.<br>• Filename pattern `stories/YYYY‑MM‑DD‑slug.jsonl`.                                                                               | • Easy lookup, keeps timeline intact.                                                                                                   | Plan cold‑storage / auto‑archive to control disk.                                       |
 | **Summarization Pipeline** | Nightly cron:<br>1. Chunk transcripts (800–1 K tokens).<br>2. Summarize with `gpt‑3.5‑turbo` (cheap).<br>3. Embed + upsert to ChromaDB.                                                                                 | • Fast search & recall.<br>• Cheap summarizer keeps bill low.                                                                           | Pennies per night.                                                                      |
@@ -16,13 +16,13 @@
 
 ## 🗺️ Implementation Road‑map (Next Steps)
 
-1. **Scaffold `/ws/storytime`** endpoint with audio → STT → TTS loop.
-2. **Save transcripts** in `stories/`, append JSONL live.
-3. **Nightly `summarize_stories.py`** cron (chunk, summarize, embed).
-4. **Intent hook** in `route_prompt` to search & cite memories.
-5. **Add cost guards**: local cache for canned TTS, confidence‑based talkback.
-6. **Later**: UI playback, emotion tags, fine‑tune voice clone.
+1. [ ] **Scaffold `/ws/storytime`** endpoint with audio → STT → TTS loop. _Not present; current code only provides `/transcribe` for live STT._
+2. [ ] **Save transcripts** in `stories/`, append JSONL live. _Current sessions write `sessions/<id>/transcript.txt`._
+3. [ ] **Nightly `summarize_stories.py`** cron (chunk, summarize, embed). _Summaries triggered manually via `/sessions/{id}/summarize`; no cron yet._
+4. [ ] **Intent hook** in `route_prompt` to search & cite memories. _Memory retrieval wiring still pending._
+5. [ ] **Add cost guards**: local cache for canned TTS, confidence‑based talkback. _Not started._
+6. [ ] **Later**: UI playback, emotion tags, fine‑tune voice clone. _Future work._
 
 ---
 
-> **Last updated:** 2025‑08‑03 — Use this doc to log future decisions, tweaks, and lessons learned.
+> **Last updated:** 2025‑08‑08 — Use this doc to log future decisions, tweaks, and lessons learned.


### PR DESCRIPTION
### Problem
Story Mode roadmap didn't reflect current code state or model costs.

### Solution
- annotate roadmap items with current implementation status
- update realtime STT model to `whisper-1`
- refresh last updated date

### Tests
`PYENV_VERSION=3.11.12 pytest tests/test_config.py -q` *(fails: ModuleNotFoundError: fastapi)*
`PYENV_VERSION=3.11.12 ruff check .` *(fails: 70 errors)*
`PYENV_VERSION=3.11.12 black --check .` *(fails: would reformat multiple files)*

### Risk
- Doc changes only

------
https://chatgpt.com/codex/tasks/task_e_6895f0e4ae10832aae6c9a76669b03e0