### PR TITLE
docs: document GesahniV2 frontend setup

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,36 +1,32 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# GesahniV2 Frontend
 
-## Getting Started
+This directory contains the [Next.js](https://nextjs.org/) web interface for GesahniV2. It provides a browser-based UI that sends prompts to the FastAPI backend and renders responses.
 
-First, run the development server:
+## Prerequisites
+- A running GesahniV2 backend. See the [root README](../README.md) for backend setup and environment configuration.
 
+## Local Development
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. (Optional) Specify the backend URL if it differs from the default:
+   ```bash
+   export NEXT_PUBLIC_API_URL="http://localhost:8000"
+   ```
+   The app falls back to `http://localhost:8000` when this variable is unset.
+3. Start the development server:
+   ```bash
+   npm run dev
+   ```
+   Visit [http://localhost:3000](http://localhost:3000) to interact with the UI.
+
+## Production Build & Deployment
+Build an optimized production bundle and run it with Node:
 ```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
+npm run build
+npm start
 ```
+You can also deploy the built app with services such as Vercel or any Node.js host.
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
-
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
-
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
-
-## Learn More
-
-To learn more about Next.js, take a look at the following resources:
-
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
-
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
-
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+For backend deployment instructions and additional environment variables, consult the [project README](../README.md).


### PR DESCRIPTION
### Problem
Frontend README contained create-next-app boilerplate without project context or setup instructions.

### Solution
Explain the frontend's role as the GesahniV2 web UI, add development and production steps, mention the `NEXT_PUBLIC_API_URL` environment variable, and link to the backend README for configuration.

### Tests
`pytest -q` *(fails: ModuleNotFoundError: No module named 'openai', etc.)*
`ruff check .` *(fails: Found 70 errors)*
`black --check .` *(fails: 9 files would be reformatted)*

### Risk
Low. Documentation-only change.

------
https://chatgpt.com/codex/tasks/task_e_6895f0eabde0832a994f0a2d3e7291ea