### PR TITLE
feat: add loading indicator for assistant replies

### DIFF
--- a/frontend/src/components/LoadingBubble.tsx
+++ b/frontend/src/components/LoadingBubble.tsx
@@ -1,0 +1,17 @@
+import { Bot } from "lucide-react";
+
+export default function LoadingBubble() {
+  return (
+    <div className="flex items-start gap-2 mb-3">
+      <div className="shrink-0 mt-1 text-muted-foreground">
+        <Bot className="size-5" />
+      </div>
+      <div className="rounded-2xl px-4 py-2 max-w-[75%] bg-card text-card-foreground">
+        <div className="flex items-center gap-2 text-sm">
+          <div className="h-4 w-4 animate-spin rounded-full border-2 border-t-transparent border-primary" />
+          <span>Thinking…</span>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
### Problem
Assistant responses showed a plain ellipsis while waiting, giving little feedback.

### Solution
Added a spinner-based `LoadingBubble` component and updated chat logic to swap it with the final assistant message once streaming begins. Ephemeral loading messages are excluded from stored history.

### Tests
`PYENV_VERSION=3.11.12 pytest -q` *(fails: ModuleNotFoundError: No module named 'aiofiles')*
`PYENV_VERSION=3.11.12 ruff check .`
`PYENV_VERSION=3.11.12 black --check .` *(fails: would reformat app/memory/api.py and others)*

### Risk
Low – touches frontend rendering only.

------
https://chatgpt.com/codex/tasks/task_e_6895f20b07e4832a8fc72392ab8f38af