### PR TITLE
refactor: build Home Assistant headers dynamically

### DIFF
--- a/app/home_assistant.py
+++ b/app/home_assistant.py
@@ -22,10 +22,15 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 # HTTP helpers
 # ---------------------------------------------------------------------------
-# Default headers; add Authorization if we actually have a token
-HEADERS: dict[str, str] = {"Content-Type": "application/json"}
-if HOME_ASSISTANT_TOKEN:
-    HEADERS["Authorization"] = f"Bearer {HOME_ASSISTANT_TOKEN}"
+
+
+def _headers() -> dict[str, str]:
+    """Build request headers using the current token."""
+    headers: dict[str, str] = {"Content-Type": "application/json"}
+    if HOME_ASSISTANT_TOKEN:
+        headers["Authorization"] = f"Bearer {HOME_ASSISTANT_TOKEN}"
+    return headers
+
 
 # Room‑name synonyms so users can say “lounge” and we map → living room
 ROOM_SYNONYMS = {
@@ -66,7 +71,7 @@ async def _request(
     data, error = await json_request(
         method,
         url,
-        headers=HEADERS,
+        headers=_headers(),
         json=json,
         timeout=timeout,
     )

--- a/tests/test_home_assistant.py
+++ b/tests/test_home_assistant.py
@@ -18,3 +18,26 @@ def test_handle_command_entity_not_found(monkeypatch):
     assert res == home_assistant.CommandResult(
         success=False, message="entity_not_found", data={"name": "kitchen"}
     )
+
+
+def test_request_picks_up_token(monkeypatch):
+    monkeypatch.delenv("HOME_ASSISTANT_TOKEN", raising=False)
+    os.environ["HOME_ASSISTANT_URL"] = "http://ha"
+    from app import home_assistant
+    import importlib
+
+    importlib.reload(home_assistant)
+
+    captured: dict[str, dict] = {}
+
+    async def fake_json_request(method, url, headers, json, timeout):  # type: ignore[override]
+        captured["headers"] = headers
+        return {}, None
+
+    monkeypatch.setattr(home_assistant, "json_request", fake_json_request)
+
+    home_assistant.HOME_ASSISTANT_TOKEN = "newtoken"
+
+    asyncio.run(home_assistant._request("GET", "/states"))
+
+    assert captured["headers"]["Authorization"] == "Bearer newtoken"


### PR DESCRIPTION
### Problem
`HEADERS` was computed at import time so later token updates were ignored.

### Solution
- replace static `HEADERS` dict with `_headers` helper
- refresh headers on every Home Assistant request
- test that late token assignment is respected

### Tests
`venv/bin/pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*
`venv/bin/ruff check .` *(fails: Found 70 errors)*
`venv/bin/black --check .` *(fails: 11 files would be reformatted)*

### Risk
Low; touches Home Assistant request helper and adds isolated test.

------
https://chatgpt.com/codex/tasks/task_e_6895f6d21ad0832a8b0a56e404cca7eb