### PR TITLE
Handle Home Assistant state fetch errors

### DIFF
--- a/app/skills/entities_skill.py
+++ b/app/skills/entities_skill.py
@@ -2,8 +2,11 @@
 from __future__ import annotations
 
 import re
+import logging
 from .base import Skill
 from .. import home_assistant as ha
+
+logger = logging.getLogger(__name__)
 
 
 class EntitiesSkill(Skill):
@@ -34,7 +37,11 @@ class EntitiesSkill(Skill):
         start, end = (page - 1) * PAGE_SIZE, page * PAGE_SIZE
 
         # grab all HA states
-        states = await ha.get_states()
+        try:
+            states = await ha.get_states()
+        except ha.HomeAssistantAPIError as e:
+            logger.warning("entities fetch failed: %s", e)
+            return "Home Assistant unreachable."
 
         # narrow to requested domain
         domain_prefix = {"lights": "light.", "switches": "switch."}.get(kind, "")

--- a/tests/test_home_assistant.py
+++ b/tests/test_home_assistant.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import asyncio
+import pytest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
@@ -18,3 +19,29 @@ def test_handle_command_entity_not_found(monkeypatch):
     assert res == home_assistant.CommandResult(
         success=False, message="entity_not_found", data={"name": "kitchen"}
     )
+
+
+def test_get_states_unreachable(monkeypatch):
+    os.environ["HOME_ASSISTANT_URL"] = "http://ha"
+    os.environ["HOME_ASSISTANT_TOKEN"] = "token"
+    from app import home_assistant
+
+    async def fake_request(method, path, json=None, timeout=10.0):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(home_assistant, "_request", fake_request)
+    with pytest.raises(home_assistant.HomeAssistantAPIError):
+        asyncio.run(home_assistant.get_states())
+
+
+def test_resolve_entity_unreachable(monkeypatch):
+    os.environ["HOME_ASSISTANT_URL"] = "http://ha"
+    os.environ["HOME_ASSISTANT_TOKEN"] = "token"
+    from app import home_assistant
+
+    async def fake_states():
+        raise home_assistant.HomeAssistantAPIError("nope")
+
+    monkeypatch.setattr(home_assistant, "get_states", fake_states)
+    res = asyncio.run(home_assistant.resolve_entity("kitchen"))
+    assert res == []


### PR DESCRIPTION
### Problem
`get_states` silently returned an empty list when the Home Assistant `/states` endpoint was unreachable, making it hard for callers and tests to differentiate between "no entities" and an error.

### Solution
- Introduced `HomeAssistantAPIError` and updated `get_states` to raise it instead of returning an empty list.
- Updated `resolve_entity` and HA-related skills to catch the new exception and degrade gracefully.
- Added tests covering unreachable `/states` endpoint scenarios.

### Tests
`PYENV_VERSION=3.11.12 python -m black --check app/home_assistant.py app/skills/lights_skill.py app/skills/entities_skill.py tests/test_home_assistant.py`
`PYENV_VERSION=3.11.12 ruff check app/home_assistant.py app/skills/lights_skill.py app/skills/entities_skill.py tests/test_home_assistant.py`
`PYENV_VERSION=3.11.12 pytest tests/test_home_assistant.py -q`

### Risk
Low. Changes are isolated to Home Assistant integrations and accompanying tests.

------
https://chatgpt.com/codex/tasks/task_e_6895f7589cfc832a853e720bcbb68cf6