### PR TITLE
Initialize HTTP logging once and add test

### DIFF
--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,6 +1,11 @@
-import sys, os
+import os
+import sys
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import importlib
+import logging
+from unittest.mock import patch
+
 import pytest
 from fastapi.testclient import TestClient
 
@@ -9,7 +14,8 @@ os.environ["OLLAMA_MODEL"] = "llama3"
 os.environ["HOME_ASSISTANT_URL"] = "http://ha"
 os.environ["HOME_ASSISTANT_TOKEN"] = "token"
 from app import main
-from app.logging_config import configure_logging
+from app.logging_config import configure_logging  # noqa: F401
+import app.http_utils as http_utils
 
 
 def test_request_id_header(monkeypatch):
@@ -18,3 +24,42 @@ def test_request_id_header(monkeypatch):
     client = TestClient(main.app)
     resp = client.get("/health")
     assert "X-Request-ID" in resp.headers
+
+
+@pytest.mark.asyncio
+async def test_http_logging_initialized_once(monkeypatch):
+    http_logger = logging.getLogger("httpx")
+    core_logger = logging.getLogger("httpcore")
+
+    http_logger.setLevel(logging.NOTSET)
+    core_logger.setLevel(logging.NOTSET)
+
+    with patch.object(http_logger, "setLevel") as http_set, patch.object(
+        core_logger, "setLevel"
+    ) as core_set:
+        importlib.reload(http_utils)
+        assert http_set.call_count == 1
+        assert core_set.call_count == 1
+
+        class DummyResp:
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return {}
+
+        class DummyClient:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                pass
+
+            async def request(self, method, url, **kwargs):
+                return DummyResp()
+
+        with patch("app.http_utils.httpx.AsyncClient", return_value=DummyClient()):
+            await http_utils.json_request("GET", "http://example.com")
+
+        assert http_set.call_count == 1
+        assert core_set.call_count == 1


### PR DESCRIPTION
### Problem
HTTP utilities set `httpx` and `httpcore` logger levels during each request, causing repeated mutations.

### Solution
- Added `_initialize_http_logging` executed at import time to configure `httpx`/`httpcore` loggers once.
- Removed per-call logger mutations in `json_request`.
- Added test ensuring logger levels are set only once.

### Tests
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*
- `python -m ruff check app/http_utils.py tests/test_logging.py`
- `python -m black --check app/http_utils.py tests/test_logging.py`
- `python -m black --check .` *(fails: 10 files would be reformatted)*

### Risk
Low. Changes focus on logging setup and isolated test additions.

------
https://chatgpt.com/codex/tasks/task_e_6895f766ee58832a9f0df1d8ef8884d6