### PR TITLE
Persist bucket reset timestamp

### DIFF
--- a/app/security.py
+++ b/app/security.py
@@ -39,7 +39,7 @@ def _bucket_rate_limit(
     """Increment ``key`` in ``bucket`` and enforce ``limit`` within ``period``."""
 
     now = time.time()
-    reset = bucket.get("_reset", now)
+    reset = bucket.setdefault("_reset", now)
     if now - reset >= period:
         bucket.clear()
         bucket["_reset"] = now

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -20,6 +20,18 @@ def test_rate_limit_prunes_empty(monkeypatch):
     assert "ip" not in security._requests
 
 
+# Added in response to bucket reset fix
+def test_bucket_counters_reset(monkeypatch):
+    bucket = {}
+    key = "ip"
+    limit = 1
+    period = 0.05
+    assert security._bucket_rate_limit(key, bucket, limit, period)
+    assert not security._bucket_rate_limit(key, bucket, limit, period)
+    time.sleep(period)
+    assert security._bucket_rate_limit(key, bucket, limit, period)
+
+
 # From main
 def _build_app(monkeypatch):
     monkeypatch.setattr(security, "RATE_LIMIT", 1)


### PR DESCRIPTION
### Problem
Rate limit buckets didn't persist their reset timestamp, risking inconsistent counter resets and lacking tests to validate expiration.

### Solution
Store the reset timestamp with `bucket.setdefault` so it's retained across calls and add a test confirming counters drop after the window elapses.

### Tests
`pytest -q` *(fails: ModuleNotFoundError: No module named 'openai')*
`ruff check .` *(fails: multiple existing lint errors)*
`black --check .` *(fails: would reformat files)*

### Risk
Low; changes are isolated to rate limiting logic and unit tests.

------
https://chatgpt.com/codex/tasks/task_e_6895f6ef8cac832a8de4bdc5d8dc43ed