### PR TITLE
Ensure tests run without model routing dry-run mode

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -7,6 +7,8 @@ import types
 
 # Ensure asynchronous tests have an event loop available and JWT auth works.
 os.environ.setdefault("JWT_SECRET", "secret")
+# Disable debug model routing unless a test explicitly enables it.
+os.environ.setdefault("DEBUG_MODEL_ROUTING", "0")
 
 # Try to import chromadb, if not, use a stub
 try:


### PR DESCRIPTION
### Problem
`DEBUG_MODEL_ROUTING` was enabled by default in the test environment, causing router tests to short‑circuit into diagnostic dry‑run strings.

### Solution
Explicitly disable model‑routing dry‑run mode in `conftest.py` so tests execute real routing paths unless a test opts in.

### Tests
`PYENV_VERSION=3.11.12 pytest tests/test_debug_model_routing.py::test_dry_run_llama_path -q` *(fails: ModuleNotFoundError: No module named 'aiosqlite')*
`PYENV_VERSION=3.11.12 ruff check .` *(fails: Found 66 errors)*
`PYENV_VERSION=3.11.12 black --check .` *(fails: 14 files would be reformatted)*

### Risk
Low. Only the test harness environment variable defaults were touched; runtime behavior is unchanged unless tests override the flag.

------
https://chatgpt.com/codex/tasks/task_e_68961a514a7c832a9eab7557bed6122e