### PR TITLE
Use dynamic llama_integration references in model picker

### DIFF
--- a/app/model_picker.py
+++ b/app/model_picker.py
@@ -3,12 +3,11 @@ import re
 import logging
 from typing import Tuple
 
-from .llama_integration import OLLAMA_MODEL, LLAMA_HEALTHY, llama_circuit_open
+from . import llama_integration
 
 logger = logging.getLogger(__name__)
 
 GPT_DEFAULT_MODEL = os.getenv("GPT_DEFAULT_MODEL", "gpt-4o")
-LLAMA_DEFAULT_MODEL = OLLAMA_MODEL or os.getenv("OLLAMA_MODEL", "llama3:latest")
 HEAVY_WORD_COUNT = int(os.getenv("MODEL_ROUTER_HEAVY_WORDS", "30"))
 HEAVY_TOKENS = int(os.getenv("MODEL_ROUTER_HEAVY_TOKENS", "1000"))
 
@@ -32,9 +31,12 @@ def pick_model(prompt: str, intent: str, tokens: int) -> Tuple[str, str]:
         )
         return "gpt", GPT_DEFAULT_MODEL
 
-    if not LLAMA_DEFAULT_MODEL:
+    llama_model = llama_integration.OLLAMA_MODEL or os.getenv(
+        "OLLAMA_MODEL", "llama3:latest"
+    )
+    if not llama_model:
         logger.warning("No LLAMA model configured—using fallback 'llama'")
-    if not LLAMA_HEALTHY or llama_circuit_open:
+    if not llama_integration.LLAMA_HEALTHY or llama_integration.llama_circuit_open:
         logger.info("LLaMA unavailable, routing to GPT")
         return "gpt", GPT_DEFAULT_MODEL
-    return "llama", LLAMA_DEFAULT_MODEL
+    return "llama", llama_model

--- a/tests/test_model_picker.py
+++ b/tests/test_model_picker.py
@@ -4,6 +4,7 @@ os.environ["OLLAMA_MODEL"] = "llama3"
 
 from app.model_picker import pick_model, GPT_DEFAULT_MODEL
 from app.llama_integration import OLLAMA_MODEL
+from app import llama_integration
 
 
 def test_pick_model_llama():
@@ -21,5 +22,12 @@ def test_pick_model_complex_long():
 
 def test_pick_model_keyword():
     engine, model = pick_model("please analyze this", "chat", 0)
+    assert engine == "gpt"
+    assert model == GPT_DEFAULT_MODEL
+
+
+def test_pick_model_llama_unhealthy(monkeypatch):
+    monkeypatch.setattr(llama_integration, "LLAMA_HEALTHY", False)
+    engine, model = pick_model("hello", "chat", 5)
     assert engine == "gpt"
     assert model == GPT_DEFAULT_MODEL


### PR DESCRIPTION
### Problem
`pick_model` cached values from `llama_integration`, so runtime updates to health flags or model name were ignored. No test verified dynamic behaviour.

### Solution
- Import the `llama_integration` module and read `OLLAMA_MODEL`, `LLAMA_HEALTHY`, and `llama_circuit_open` at call time.
- Add a test that toggles `LLAMA_HEALTHY` to ensure GPT fallback when LLaMA is unhealthy.

### Tests
- `ruff check .` *(fails: multiple existing lint errors)*
- `black --check .` *(fails: would reformat many files)*
- `pytest -q` *(fails: missing dependencies like `pydantic`, `httpx`, and `fastapi`)*
- `ruff check app/model_picker.py tests/test_model_picker.py`
- `black --check app/model_picker.py tests/test_model_picker.py`

### Risk
Low; changes are isolated to model selection and tests.


------
https://chatgpt.com/codex/tasks/task_e_68961c3334b8832a8af2675b71e3f34b