### PR TITLE
Refactor model picker llama import and add health test

### DIFF
--- a/app/model_picker.py
+++ b/app/model_picker.py
@@ -3,12 +3,14 @@ import re
 import logging
 from typing import Tuple
 
-from .llama_integration import OLLAMA_MODEL, LLAMA_HEALTHY, llama_circuit_open
+from . import llama_integration
 
 logger = logging.getLogger(__name__)
 
 GPT_DEFAULT_MODEL = os.getenv("GPT_DEFAULT_MODEL", "gpt-4o")
-LLAMA_DEFAULT_MODEL = OLLAMA_MODEL or os.getenv("OLLAMA_MODEL", "llama3:latest")
+LLAMA_DEFAULT_MODEL = llama_integration.OLLAMA_MODEL or os.getenv(
+    "OLLAMA_MODEL", "llama3:latest"
+)
 HEAVY_WORD_COUNT = int(os.getenv("MODEL_ROUTER_HEAVY_WORDS", "30"))
 HEAVY_TOKENS = int(os.getenv("MODEL_ROUTER_HEAVY_TOKENS", "1000"))
 
@@ -34,7 +36,7 @@ def pick_model(prompt: str, intent: str, tokens: int) -> Tuple[str, str]:
 
     if not LLAMA_DEFAULT_MODEL:
         logger.warning("No LLAMA model configured—using fallback 'llama'")
-    if not LLAMA_HEALTHY or llama_circuit_open:
+    if not llama_integration.LLAMA_HEALTHY or llama_integration.llama_circuit_open:
         logger.info("LLaMA unavailable, routing to GPT")
         return "gpt", GPT_DEFAULT_MODEL
     return "llama", LLAMA_DEFAULT_MODEL

--- a/tests/test_model_picker.py
+++ b/tests/test_model_picker.py
@@ -1,15 +1,16 @@
 import os
 
 os.environ["OLLAMA_MODEL"] = "llama3"
+os.environ.setdefault("OLLAMA_URL", "http://localhost:11434")
 
 from app.model_picker import pick_model, GPT_DEFAULT_MODEL
-from app.llama_integration import OLLAMA_MODEL
+import app.llama_integration as llama_integration
 
 
 def test_pick_model_llama():
     engine, model = pick_model("hello", "chat", 5)
     assert engine == "llama"
-    assert model == OLLAMA_MODEL or model == "llama3"
+    assert model == llama_integration.OLLAMA_MODEL or model == "llama3"
 
 
 def test_pick_model_complex_long():
@@ -21,5 +22,12 @@ def test_pick_model_complex_long():
 
 def test_pick_model_keyword():
     engine, model = pick_model("please analyze this", "chat", 0)
+    assert engine == "gpt"
+    assert model == GPT_DEFAULT_MODEL
+
+
+def test_pick_model_llama_unhealthy(monkeypatch):
+    monkeypatch.setattr(llama_integration, "LLAMA_HEALTHY", False)
+    engine, model = pick_model("hi", "chat", 1)
     assert engine == "gpt"
     assert model == GPT_DEFAULT_MODEL


### PR DESCRIPTION
### Problem
`model_picker` imported LLaMA health constants directly, making it harder to patch and reference module state.

### Solution
- Import the entire `llama_integration` module and reference its attributes.
- Added test ensuring GPT is chosen when LLaMA is flagged unhealthy.

### Tests
`pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*
`pytest tests/test_model_picker.py -q`
`ruff check .` *(fails: multiple lint errors across repository)*
`ruff check tests/test_model_picker.py app/model_picker.py`
`black --check .` *(fails: 14 files would be reformatted)*
`black --check tests/test_model_picker.py app/model_picker.py`

### Risk
Low. Changes are limited to model selection logic and its tests.

------
https://chatgpt.com/codex/tasks/task_e_68961c446d78832a9f5be258410fd9c4