### PR TITLE
Add embedder type for Chroma compatibility

### DIFF
--- a/app/memory/chroma_store.py
+++ b/app/memory/chroma_store.py
@@ -24,6 +24,8 @@ logger = logging.getLogger(__name__)
 
 
 class _LengthEmbedder:
+    _type = "LengthEmbedder"
+
     def __call__(self, input: List[str]) -> List[List[float]]:
         import numpy as np
         return [np.asarray([float(len(_normalize(t)[1]))], dtype=np.float32) for t in input]


### PR DESCRIPTION
### Problem
`_LengthEmbedder` lacked a `_type` attribute, causing incompatibility with Chromadb clients.

### Solution
Add `_type = "LengthEmbedder"` to `_LengthEmbedder` so Chromadb clients can recognize the custom embedder.

### Tests
`ruff check .` *(fails: Found 66 errors)*
`black --check app/memory/chroma_store.py` *(fails: would reformat)*
`python3 -m pytest tests/test_dedup.py::test_dedup_middleware` (passes)

### Risk
Low. Change adds metadata to embedder without affecting runtime logic.


------
https://chatgpt.com/codex/tasks/task_e_68961c253e44832a9fcc5c36803c53f2