### PR TITLE
Check LLaMA circuit before GPT fallback

### DIFF
--- a/app/router.py
+++ b/app/router.py
@@ -276,6 +276,12 @@ async def route_prompt(
             gen_opts=gen_opts,
         )
 
+    if engine == "llama" and not llama_integration.LLAMA_HEALTHY:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="LLaMA circuit open",
+        )
+
     # Fallback GPT-4o
     if debug_route:
         return _dry("gpt", "gpt-4o")


### PR DESCRIPTION
### Problem
GPT fallback could be used even when the LLaMA circuit breaker is open, letting traffic bypass the intended outage.

### Solution
* Guard `route_prompt` to raise HTTP 503 with `"LLaMA circuit open"` when a LLaMA model is selected but marked unhealthy.
* Update `test_llama_circuit_open` to expect the new HTTP error detail.

### Tests
`python -m black --check app/router.py tests/test_router.py`
`ruff check app/router.py tests/test_router.py`
`pytest -q` *(fails: No module named 'numpy', 'jwt', 'dotenv', etc.)*

### Risk
Low. The new guard only triggers when LLaMA is explicitly selected but the health flag is down, preserving existing fallback flows otherwise.

------
https://chatgpt.com/codex/tasks/task_e_68961c4daff8832aae024b331d898123