### PR TITLE
Use L2 space for Chroma length embeddings

### DIFF
--- a/app/memory/chroma_store.py
+++ b/app/memory/chroma_store.py
@@ -80,13 +80,27 @@ class ChromaVectorStore(VectorStore):
 
         self._client = client
         self._embedder = _LengthEmbedder()
-        base_cache = self._client.get_or_create_collection(
-            "qa_cache", embedding_function=self._embedder
-        )
+        try:
+            base_cache = self._client.get_or_create_collection(
+                "qa_cache",
+                embedding_function=self._embedder,
+                metadata={"hnsw:space": "l2"},
+            )
+        except TypeError:
+            base_cache = self._client.get_or_create_collection(
+                "qa_cache", embedding_function=self._embedder
+            )
         self._cache = _ChromaCacheWrapper(base_cache)
-        self._user_memories = self._client.get_or_create_collection(
-            "user_memories", embedding_function=self._embedder
-        )
+        try:
+            self._user_memories = self._client.get_or_create_collection(
+                "user_memories",
+                embedding_function=self._embedder,
+                metadata={"hnsw:space": "l2"},
+            )
+        except TypeError:
+            self._user_memories = self._client.get_or_create_collection(
+                "user_memories", embedding_function=self._embedder
+            )
 
     def add_user_memory(self, user_id: str, memory: str) -> str:
         mem_id = str(uuid.uuid4())


### PR DESCRIPTION
### Problem
Vector store collections defaulted to cosine similarity, making length-based distances zero and defeating threshold checks.

### Solution
Specify `metadata={"hnsw:space": "l2"}` when creating `qa_cache` and `user_memories` collections, with graceful fallback for older clients. Updated the test stub to handle the metadata and compute L2 distances.

### Tests
`/tmp/venv/bin/python -m pytest tests/test_vector_store_threshold.py::test_cache_miss_high_threshold -q`
`/tmp/venv/bin/ruff check .`
`/tmp/venv/bin/black --check .`

### Risk
Low: affects Chroma initialization and test stub only.

------
https://chatgpt.com/codex/tasks/task_e_6896418cab4c832aaf6065d6ba74103d