### PR TITLE
test: isolate llama health flag

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,11 @@
+"""Test-specific fixtures."""
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _reset_llama_health():
+    """Ensure ``LLAMA_HEALTHY`` starts True for each test."""
+    from app import llama_integration
+
+    llama_integration.LLAMA_HEALTHY = True

--- a/tests/test_debug_model_routing.py
+++ b/tests/test_debug_model_routing.py
@@ -34,7 +34,7 @@ def test_dry_run_llama_path(monkeypatch, caplog):
     _setup_env(monkeypatch)
     from app import router, llama_integration
 
-    llama_integration.LLAMA_HEALTHY = True
+    monkeypatch.setattr(llama_integration, "LLAMA_HEALTHY", True)
     _common_patches(monkeypatch, router)
     monkeypatch.setattr(router, "ask_llama", _fail)
     monkeypatch.setattr(router, "ask_gpt", _fail)
@@ -50,7 +50,7 @@ def test_dry_run_gpt_fallback(monkeypatch, caplog):
     _setup_env(monkeypatch)
     from app import router, llama_integration
 
-    llama_integration.LLAMA_HEALTHY = False
+    monkeypatch.setattr(llama_integration, "LLAMA_HEALTHY", False)
     _common_patches(monkeypatch, router)
     monkeypatch.setattr(router, "ask_llama", _fail)
     monkeypatch.setattr(router, "ask_gpt", _fail)

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -108,7 +108,7 @@ def test_router_fallback_metrics_updated(monkeypatch):
     os.environ["HOME_ASSISTANT_TOKEN"] = "token"
     from app import router, analytics, llama_integration
 
-    llama_integration.LLAMA_HEALTHY = True
+    monkeypatch.setattr(llama_integration, "LLAMA_HEALTHY", True)
 
     async def fake_llama(prompt, model=None):
         return {"error": "timeout", "llm_used": "llama3"}
@@ -219,7 +219,7 @@ def test_complexity_checks(monkeypatch):
     os.environ["HOME_ASSISTANT_TOKEN"] = "token"
     from app import router, llama_integration
 
-    llama_integration.LLAMA_HEALTHY = True
+    monkeypatch.setattr(llama_integration, "LLAMA_HEALTHY", True)
 
     async def fake_gpt(prompt, model=None, system=None, **kwargs):
         return "gpt", 0, 0, 0.0
@@ -286,7 +286,7 @@ def test_debug_env_toggle(monkeypatch):
 
     monkeypatch.setattr(router, "handle_command", handle_cmd)
     monkeypatch.setattr(router, "lookup_cached_answer", lambda p: None)
-    router.LLAMA_HEALTHY = False
+    monkeypatch.setattr(router, "LLAMA_HEALTHY", False)
     monkeypatch.setattr(router.memgpt, "store_interaction", lambda *a, **k: None)
     monkeypatch.setattr(router, "add_user_memory", lambda *a, **k: None)
     monkeypatch.setattr(
@@ -339,7 +339,7 @@ def test_generation_options_passthrough(monkeypatch):
     monkeypatch.setattr(router, "lookup_cached_answer", lambda p: None)
     monkeypatch.setattr(router, "pick_model", lambda *a, **k: ("llama", "llama3"))
     monkeypatch.setattr(router, "detect_intent", lambda p: ("chat", "high"))
-    router.LLAMA_HEALTHY = True
+    monkeypatch.setattr(router, "LLAMA_HEALTHY", True)
     monkeypatch.setattr(router.memgpt, "store_interaction", lambda *a, **k: None)
     monkeypatch.setattr(router, "add_user_memory", lambda *a, **k: None)
     monkeypatch.setattr(

--- a/tests/test_router_extras.py
+++ b/tests/test_router_extras.py
@@ -16,7 +16,7 @@ def test_llama_override(monkeypatch):
     _setup_env()
     from app import router, llama_integration
 
-    llama_integration.LLAMA_HEALTHY = True
+    monkeypatch.setattr(llama_integration, "LLAMA_HEALTHY", True)
 
     async def fake_llama(prompt, model=None):
         for tok in ["ok"]:
@@ -33,7 +33,7 @@ def test_cache_hit(monkeypatch):
     from app import router, llama_integration
     from app.memory import vector_store
 
-    llama_integration.LLAMA_HEALTHY = False
+    monkeypatch.setattr(llama_integration, "LLAMA_HEALTHY", False)
 
     async def fake_gpt(prompt, model=None, system=None):
         return "cached", 0, 0, 0.0
@@ -64,7 +64,7 @@ def test_low_conf_rejection(monkeypatch):
     _setup_env()
     from app import router, llama_integration
 
-    llama_integration.LLAMA_HEALTHY = True
+    monkeypatch.setattr(llama_integration, "LLAMA_HEALTHY", True)
 
     async def low_conf(prompt, model=None):
         for tok in ["I don't know"]:

--- a/tests/test_router_llama_fallback.py
+++ b/tests/test_router_llama_fallback.py
@@ -16,7 +16,7 @@ def test_llama_circuit_open_routes_to_gpt(monkeypatch):
     _setup_env()
     from app import router, llama_integration
 
-    llama_integration.LLAMA_HEALTHY = True
+    monkeypatch.setattr(llama_integration, "LLAMA_HEALTHY", True)
     router.llama_circuit_open = True
 
     async def fake_gpt(**kwargs):
@@ -49,8 +49,8 @@ def test_gpt_failure_falls_back_to_llama(monkeypatch):
     _setup_env()
     from app import router, llama_integration
 
-    llama_integration.LLAMA_HEALTHY = True
-    router.LLAMA_HEALTHY = True
+    monkeypatch.setattr(llama_integration, "LLAMA_HEALTHY", True)
+    monkeypatch.setattr(router, "LLAMA_HEALTHY", True)
 
     async def fail_gpt(**kwargs):
         raise RuntimeError("boom")
@@ -73,8 +73,8 @@ def test_gpt_failure_raises_when_llama_unhealthy(monkeypatch):
     _setup_env()
     from app import router, llama_integration
 
-    llama_integration.LLAMA_HEALTHY = False
-    router.LLAMA_HEALTHY = False
+    monkeypatch.setattr(llama_integration, "LLAMA_HEALTHY", False)
+    monkeypatch.setattr(router, "LLAMA_HEALTHY", False)
 
     async def fail_gpt(**kwargs):
         raise RuntimeError("boom")
@@ -93,8 +93,8 @@ def test_gpt_override_failure_falls_back_to_llama(monkeypatch):
     _setup_env()
     from app import router, llama_integration
 
-    llama_integration.LLAMA_HEALTHY = True
-    router.LLAMA_HEALTHY = True
+    monkeypatch.setattr(llama_integration, "LLAMA_HEALTHY", True)
+    monkeypatch.setattr(router, "LLAMA_HEALTHY", True)
 
     async def fail_override(*args, **kwargs):
         raise RuntimeError("boom")
@@ -114,8 +114,8 @@ def test_empty_llama_response_falls_back_to_gpt(monkeypatch):
     _setup_env()
     from app import router, llama_integration
 
-    llama_integration.LLAMA_HEALTHY = True
-    router.LLAMA_HEALTHY = True
+    monkeypatch.setattr(llama_integration, "LLAMA_HEALTHY", True)
+    monkeypatch.setattr(router, "LLAMA_HEALTHY", True)
 
     def fake_llama(**kwargs):
         return ""
@@ -139,8 +139,8 @@ def test_low_conf_llama_response_falls_back_to_gpt(monkeypatch):
     _setup_env()
     from app import router, llama_integration
 
-    llama_integration.LLAMA_HEALTHY = True
-    router.LLAMA_HEALTHY = True
+    monkeypatch.setattr(llama_integration, "LLAMA_HEALTHY", True)
+    monkeypatch.setattr(router, "LLAMA_HEALTHY", True)
 
     def fake_llama(**kwargs):
         return "I don't know"


### PR DESCRIPTION
### Problem
Global LLAMA_HEALTHY state was being modified directly in tests, leading to cross-test leakage.

### Solution
- Added an autouse fixture under `tests/` to reset `llama_integration.LLAMA_HEALTHY`.
- Replaced direct assignments with `monkeypatch.setattr` across routing tests.

### Tests
`ruff check .` *(fails: Multiple imports on one line, unused imports)*
`black --check .` *(fails: would reformat several files)*
`pytest -q` *(fails: missing modules like `aiofiles`, `jose`, `tenacity`)*

### Risk
Low: changes are limited to test scaffolding and monkeypatch usage.

------
https://chatgpt.com/codex/tasks/task_e_689641629188832a908ef4c20c193f00