### PR TITLE
Cache prompt core and refine prompt builder typing

### DIFF
--- a/app/memory/vector_store/__init__.py
+++ b/app/memory/vector_store/__init__.py
@@ -1,4 +1,10 @@
-"""Compatibility wrapper re-exporting vector store API."""
+"""Compatibility wrapper re-exporting vector store API.
+
+This module centralizes vector store helpers under a single import path.
+Tests rely on these re-exports to avoid pulling in heavy dependencies and
+they provide a seam for swapping out the underlying provider in the future
+without touching call sites.
+"""
 
 from ..api import (
     ChromaVectorStore,
@@ -16,6 +22,7 @@ from ..api import (
 )
 from app.embeddings import embed_sync as _embed_sync
 from ..env_utils import _normalize as _normalize, _normalized_hash as _normalized_hash
+
 embed_sync = _embed_sync
 
 
@@ -35,7 +42,6 @@ __all__ = [
     "_normalize",
     "_normalized_hash",
     "embed_sync",
-
 ]
 
 # Re-export internal helper for tests that import module._get_store
@@ -43,4 +49,3 @@ try:  # pragma: no cover - test-only import path
     from ..api import _get_store as _get_store  # type: ignore
 except Exception:  # pragma: no cover - defensive
     pass
-

--- a/tests/test_prompt_builder.py
+++ b/tests/test_prompt_builder.py
@@ -46,8 +46,8 @@ sys.modules.setdefault(
     types.SimpleNamespace(EmbeddingFunction=object),
 )
 
-from app import prompt_builder
-from app.prompt_builder import PromptBuilder, MAX_PROMPT_TOKENS
+from app import prompt_builder  # noqa: E402
+from app.prompt_builder import PromptBuilder, MAX_PROMPT_TOKENS  # noqa: E402
 
 
 def test_prompt_builder_respects_token_limit(monkeypatch):
@@ -103,8 +103,8 @@ def test_prompt_builder_fills_all_fields(monkeypatch):
 def test_prompt_builder_drops_summary_before_memories(monkeypatch):
     monkeypatch.setattr(
         prompt_builder,
-        "_PROMPT_CORE",
-        "{{conversation_summary}} {{memories}} {{user_prompt}}",
+        "_prompt_core",
+        lambda: "{{conversation_summary}} {{memories}} {{user_prompt}}",
     )
     monkeypatch.setattr(prompt_builder, "count_tokens", lambda text: len(text))
     monkeypatch.setattr(prompt_builder, "MAX_PROMPT_TOKENS", 50)


### PR DESCRIPTION
### Problem
- `PromptBuilder.build` returned `Tuple[str, int]` and read the prompt template at import time.
- Vector store re-export module lacked context for its role in tests and future backend swaps.

### Solution
- Annotated `PromptBuilder.build` with `tuple[str, int]` and introduced a cached `_prompt_core()` loader.
- Expanded vector store docstring to explain re-exports supporting tests and provider swaps.
- Updated tests to patch the new helper.

### Tests
`pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi', 'pydantic', 'numpy', etc.)*
`ruff check .` *(fails: Found 65 errors such as E401 multiple imports on one line)*
`black --check .` *(fails: would reformat many files including app/embeddings.py)*

### Risk
Low. Changes are isolated to prompt construction utilities and documentation with no behavioral impact beyond improved caching.

------
https://chatgpt.com/codex/tasks/task_e_68964e4b2ee0832a80f24d8cf9852831