### PR TITLE
feat: add safe memory query helper

### DIFF
--- a/app/memory/vector_store/__init__.py
+++ b/app/memory/vector_store/__init__.py
@@ -1,5 +1,7 @@
 """Compatibility wrapper re-exporting vector store API."""
 
+from typing import List
+
 from ..api import (
     ChromaVectorStore,
     MemoryVectorStore,
@@ -16,12 +18,51 @@ from ..api import (
 )
 from app.embeddings import embed_sync as _embed_sync
 from ..env_utils import _normalize as _normalize, _normalized_hash as _normalized_hash
+
 embed_sync = _embed_sync
+
+
+def _coerce_k(k: int | str | None) -> int | None:
+    """Return ``k`` as an ``int`` when possible.
+
+    A ``None`` or invalid value returns ``None`` so that callers may
+    apply their own defaults.
+    """
+
+    if k is None:
+        return None
+    if isinstance(k, str):
+        try:
+            return int(k)
+        except ValueError:
+            return None
+    return k
+
+
+def safe_query_user_memories(
+    user_id: str, prompt: str, *, k: int | str | None = None
+) -> List[str]:
+    """Wrapper around :func:`query_user_memories` that coerces ``k``.
+
+    Parameters
+    ----------
+    user_id:
+        The user identifier whose memories to query.
+    prompt:
+        The prompt text used to search memories.
+    k:
+        Desired number of memories to retrieve. Accepts ``int`` or ``str``
+        values; invalid inputs fall back to ``None`` which triggers the
+        default behaviour of :func:`query_user_memories`.
+    """
+
+    return query_user_memories(user_id, prompt, k=_coerce_k(k))
 
 
 __all__ = [
     "add_user_memory",
     "query_user_memories",
+    "safe_query_user_memories",
     "cache_answer",
     "cache_answer_legacy",
     "lookup_cached_answer",
@@ -35,7 +76,6 @@ __all__ = [
     "_normalize",
     "_normalized_hash",
     "embed_sync",
-
 ]
 
 # Re-export internal helper for tests that import module._get_store
@@ -43,4 +83,3 @@ try:  # pragma: no cover - test-only import path
     from ..api import _get_store as _get_store  # type: ignore
 except Exception:  # pragma: no cover - defensive
     pass
-

--- a/app/prompt_builder.py
+++ b/app/prompt_builder.py
@@ -12,7 +12,7 @@ import logging
 from .token_utils import count_tokens
 from .memory import memgpt
 from .memory.env_utils import _get_mem_top_k
-from .memory.vector_store import query_user_memories
+from .memory.vector_store import safe_query_user_memories
 from .telemetry import log_record_var
 
 MAX_PROMPT_TOKENS = 8_000
@@ -56,7 +56,9 @@ class PromptBuilder:
         if rec:
             rec.embed_tokens = count_tokens(user_prompt)
             rec.rag_top_k = top_k
-        memories: List[str] = query_user_memories(user_id, user_prompt, k=top_k)[:3]
+        memories: List[str] = safe_query_user_memories(user_id, user_prompt, k=top_k)[
+            :3
+        ]
         while count_tokens("\n".join(memories)) > 55 and memories:
             memories.pop()
         dbg = debug_info if debug else ""

--- a/tests/test_builder_defaults_top_k.py
+++ b/tests/test_builder_defaults_top_k.py
@@ -61,7 +61,7 @@ def test_builder_defaults_top_k(monkeypatch):
     monkeypatch.setattr(
         prompt_builder.memgpt, "summarize_session", lambda sid, user_id=None: ""
     )
-    monkeypatch.setattr(prompt_builder, "query_user_memories", fake_query)
+    monkeypatch.setattr(prompt_builder, "safe_query_user_memories", fake_query)
 
     PromptBuilder.build("hi", session_id="s", user_id="u")
     assert captured["k"] == 5

--- a/tests/test_prompt_builder.py
+++ b/tests/test_prompt_builder.py
@@ -56,7 +56,7 @@ def test_prompt_builder_respects_token_limit(monkeypatch):
         prompt_builder.memgpt, "summarize_session", lambda sid, user_id=None: big
     )
     monkeypatch.setattr(
-        prompt_builder, "query_user_memories", lambda uid, q, k=5: [big, big]
+        prompt_builder, "safe_query_user_memories", lambda uid, q, k=5: [big, big]
     )
 
     prompt, tokens = PromptBuilder.build("hi", session_id="s", user_id="u")
@@ -67,7 +67,9 @@ def test_prompt_builder_includes_user_prompt(monkeypatch):
     monkeypatch.setattr(
         prompt_builder.memgpt, "summarize_session", lambda sid, user_id=None: ""
     )
-    monkeypatch.setattr(prompt_builder, "query_user_memories", lambda uid, q, k=5: [])
+    monkeypatch.setattr(
+        prompt_builder, "safe_query_user_memories", lambda uid, q, k=5: []
+    )
     user_msg = "what is the weather?"
     prompt, _ = PromptBuilder.build(user_msg, session_id="s", user_id="u")
     assert user_msg in prompt
@@ -81,7 +83,7 @@ def test_prompt_builder_fills_all_fields(monkeypatch):
     )
     monkeypatch.setattr(
         prompt_builder,
-        "query_user_memories",
+        "safe_query_user_memories",
         lambda uid, q, k=5: ["memory1", "memory2"],
     )
     prompt, _ = PromptBuilder.build(
@@ -114,7 +116,7 @@ def test_prompt_builder_drops_summary_before_memories(monkeypatch):
         lambda sid, user_id=None: "S" * 40,
     )
     monkeypatch.setattr(
-        prompt_builder, "query_user_memories", lambda uid, q, k=5: ["M" * 30]
+        prompt_builder, "safe_query_user_memories", lambda uid, q, k=5: ["M" * 30]
     )
     prompt, _ = PromptBuilder.build("hi", session_id="s", user_id="u")
     assert "S" * 40 not in prompt

--- a/tests/test_retriever_budget.py
+++ b/tests/test_retriever_budget.py
@@ -57,7 +57,7 @@ def test_retriever_budget(monkeypatch):
     # five memories ~10 tokens each
     mems = [f"memory {i} " * 5 for i in range(5)]
     monkeypatch.setattr(
-        prompt_builder, "query_user_memories", lambda uid, q, k=5: mems[:k]
+        prompt_builder, "safe_query_user_memories", lambda uid, q, k=5: mems[:k]
     )
 
     base_prompt, base_tokens = PromptBuilder.build("hi", top_k=0)

--- a/tests/test_safe_query_user_memories.py
+++ b/tests/test_safe_query_user_memories.py
@@ -1,0 +1,17 @@
+from app.memory import vector_store
+
+
+def test_safe_query_user_memories_coerces_k(monkeypatch):
+    captured: dict[str, int | None] = {}
+
+    def fake_query(uid: str, prompt: str, k=None):
+        captured["k"] = k
+        return []
+
+    monkeypatch.setattr(vector_store, "query_user_memories", fake_query)
+
+    vector_store.safe_query_user_memories("u", "p", k="3")
+    assert captured["k"] == 3
+
+    vector_store.safe_query_user_memories("u", "p", k="bad")
+    assert captured["k"] is None

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -40,7 +40,7 @@ def test_telemetry_logged(monkeypatch, tmp_path):
         prompt_builder.memgpt, "summarize_session", lambda sid, user_id=None: ""
     )
     monkeypatch.setattr(
-        prompt_builder, "query_user_memories", lambda uid, q, k=5: ["m1", "m2"]
+        prompt_builder, "safe_query_user_memories", lambda uid, q, k=5: ["m1", "m2"]
     )
     resp = client.post("/ask", json={"prompt": "hi"})
     assert resp.status_code == 200


### PR DESCRIPTION
### Problem
`query_user_memories` expected an integer `k` and would error if a string or invalid value was passed (e.g. from request params).

### Solution
- add `_coerce_k` and `safe_query_user_memories` which sanitises `k` before delegating to the existing `query_user_memories`
- switch `PromptBuilder` to use the safe wrapper
- update and add tests for the new behaviour

### Tests
`pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*
`ruff check .` *(fails: Found 65 errors)*
`black --check .` *(fails: 12 files would be reformatted)*

### Risk
Low. The wrapper only normalises the `k` argument before calling the existing query function.

------
https://chatgpt.com/codex/tasks/task_e_68964e489d04832aa1e6c79194b1c13d