### PR TITLE
Sanitize memory top_k handling

### DIFF
--- a/app/memory/api.py
+++ b/app/memory/api.py
@@ -51,11 +51,23 @@ def add_user_memory(user_id: str, memory: str) -> str:
     return _store.add_user_memory(user_id, memory)
 
 
-def query_user_memories(user_id: str, prompt: str, k: int | None = None) -> List[str]:
+def _coerce_k(k: int | str | None) -> int:
+    """Return a positive integer ``k`` with a sensible default."""
+
     if k is None:
-        k = _get_mem_top_k()
-    assert isinstance(k, int), "k must be int"
-    return _store.query_user_memories(user_id, prompt, k)
+        return _get_mem_top_k()
+    try:
+        value = int(k)
+    except (TypeError, ValueError):
+        return _get_mem_top_k()
+    return value if value > 0 else _get_mem_top_k()
+
+
+def query_user_memories(
+    user_id: str, prompt: str, k: int | str | None = None
+) -> List[str]:
+    k_int = _coerce_k(k)
+    return _store.query_user_memories(user_id, prompt, k_int)
 
 
 def cache_answer(prompt: str, answer: str, cache_id: str | None = None) -> None:

--- a/tests/test_coerce_k.py
+++ b/tests/test_coerce_k.py
@@ -1,0 +1,41 @@
+import pytest
+
+from app import prompt_builder
+from app.memory import api as memory_api
+from app.memory.env_utils import DEFAULT_MEM_TOP_K
+from app.prompt_builder import PromptBuilder
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        (None, DEFAULT_MEM_TOP_K),
+        ("", DEFAULT_MEM_TOP_K),
+        ("3", 3),
+        (0, DEFAULT_MEM_TOP_K),
+    ],
+)
+def test_coerce_k(monkeypatch, raw, expected):
+    monkeypatch.setattr(memory_api, "_get_mem_top_k", lambda: DEFAULT_MEM_TOP_K)
+    assert memory_api._coerce_k(raw) == expected
+
+
+@pytest.mark.asyncio
+async def test_build_sanitizes_top_k(monkeypatch):
+    monkeypatch.setattr(
+        prompt_builder.memgpt, "summarize_session", lambda sid, user_id=None: ""
+    )
+    monkeypatch.setattr(prompt_builder, "_get_mem_top_k", lambda: "0")
+    monkeypatch.setattr(memory_api, "_get_mem_top_k", lambda: DEFAULT_MEM_TOP_K)
+
+    captured = {}
+
+    class DummyStore:
+        def query_user_memories(self, user_id, prompt, k):
+            captured["k"] = k
+            return []
+
+    monkeypatch.setattr(memory_api, "_store", DummyStore())
+
+    PromptBuilder.build("hello", session_id="s", user_id="u")
+    assert captured["k"] == DEFAULT_MEM_TOP_K


### PR DESCRIPTION
### Problem
`query_user_memories` accepted arbitrary `k` values and `PromptBuilder` could forward unsanitized values to the vector store.

### Solution
- Added `_coerce_k` helper to normalize and validate `k` before querying the vector store.
- Added tests verifying `_coerce_k` behavior and that `PromptBuilder.build` forwards a sanitized `k` when `top_k` is `None`.

### Tests
`python -m pytest tests/test_coerce_k.py tests/test_builder_defaults_top_k.py -q`
`python -m pytest -q` *(fails: GPT backend unavailable; openai package not installed)*
`ruff check .` *(fails: multiple existing lint errors across repo)*
`black --check .` *(fails: several files need reformatting)*

### Risk
Low. Changes are isolated to memory query parameter handling and new tests.

------
https://chatgpt.com/codex/tasks/task_e_68964e4a0b08832a83efae244cd79531