### PR TITLE
Add debug logging for memory k coercion and queries

### DIFF
--- a/app/memory/api.py
+++ b/app/memory/api.py
@@ -54,13 +54,18 @@ def add_user_memory(user_id: str, memory: str) -> str:
 def _coerce_k(k: int | str | None) -> int:
     """Return a positive integer ``k`` with a sensible default."""
 
+    raw = k
     if k is None:
-        return _get_mem_top_k()
-    try:
-        value = int(k)
-    except (TypeError, ValueError):
-        return _get_mem_top_k()
-    return value if value > 0 else _get_mem_top_k()
+        coerced = _get_mem_top_k()
+    else:
+        try:
+            value = int(k)
+        except (TypeError, ValueError):
+            coerced = _get_mem_top_k()
+        else:
+            coerced = value if value > 0 else _get_mem_top_k()
+    logger.debug("_coerce_k: raw=%r coerced=%d", raw, coerced)
+    return coerced
 
 
 def query_user_memories(

--- a/app/prompt_builder.py
+++ b/app/prompt_builder.py
@@ -42,20 +42,27 @@ def _coerce_k(value: int | str | None) -> int:
     Falls back to the project-wide default when the supplied value is
     missing or invalid.
     """
+    raw = value
     if value is None:
-        return _get_mem_top_k()
-
-    try:
-        k = int(value)
-    except (TypeError, ValueError):
-        logger.warning("Invalid top_k %r; defaulting to %s", value, _get_mem_top_k())
-        return _get_mem_top_k()
-
-    if k <= 0:
-        logger.warning("top_k %d must be positive; defaulting to %s", k, _get_mem_top_k())
-        return _get_mem_top_k()
-
-    return k
+        coerced = _get_mem_top_k()
+    else:
+        try:
+            k = int(value)
+        except (TypeError, ValueError):
+            logger.warning(
+                "Invalid top_k %r; defaulting to %s", value, _get_mem_top_k()
+            )
+            coerced = _get_mem_top_k()
+        else:
+            if k <= 0:
+                logger.warning(
+                    "top_k %d must be positive; defaulting to %s", k, _get_mem_top_k()
+                )
+                coerced = _get_mem_top_k()
+            else:
+                coerced = k
+    logger.debug("_coerce_k: raw=%r coerced=%d", raw, coerced)
+    return coerced
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
### Problem
Hard to inspect how memory retrieval `k` values are interpreted and what `safe_query_user_memories` returns.

### Solution
- Log raw and coerced `k` values in `_coerce_k` helpers.
- Log `safe_query_user_memories` arguments and number of memories returned.

### Tests
`ruff check .` *(fails: 63 errors)*
`black --check .` *(fails: would reformat 13 files)*
`pytest -q` *(fails: missing dependencies such as pydantic, httpx, fastapi, numpy)*

### Risk
Low. Changes only add debug logging; behaviour is unchanged. Further work may be required to install dependencies for tests and linting.

------
https://chatgpt.com/codex/tasks/task_e_689657738f40832abf95f68c403bb16b