### PR TITLE
log vector store queries

### DIFF
--- a/tests/test_vector_store_logging.py
+++ b/tests/test_vector_store_logging.py
@@ -1,0 +1,30 @@
+import logging
+import os
+import pytest
+
+from app.memory.memory_store import MemoryVectorStore
+from app.memory.chroma_store import ChromaVectorStore
+
+
+def test_memory_store_logs(caplog):
+    store = MemoryVectorStore()
+    store.add_user_memory("u", "hello")
+    with caplog.at_level(logging.INFO, logger="app.memory.memory_store"):
+        res = store.query_user_memories("u", "hello", k=1)
+    assert res == ["hello"]
+    messages = [r.message for r in caplog.records]
+    assert any("start user_id=u" in m for m in messages)
+    assert any("end user_id=u" in m and "returned=1" in m for m in messages)
+
+
+def test_chroma_store_logs(caplog, tmp_path):
+    pytest.importorskip("chromadb")
+    os.environ["CHROMA_PATH"] = str(tmp_path)
+    store = ChromaVectorStore()
+    store.add_user_memory("u", "hello")
+    with caplog.at_level(logging.INFO, logger="app.memory.chroma_store"):
+        res = store.query_user_memories("u", "hello", k=1)
+    assert res == ["hello"]
+    messages = [r.message for r in caplog.records]
+    assert any("start user_id=u" in m for m in messages)
+    assert any("end user_id=u" in m and "returned=1" in m for m in messages)


### PR DESCRIPTION
### Problem
Vector store lookups lacked visibility, making it hard to trace retrieval behavior.

### Solution
- Log entry/exit details for `MemoryVectorStore.query_user_memories` and `ChromaVectorStore.query_user_memories` including user, prompt, k, result count, and distances.
- Added tests covering both vector store backends.

### Tests
- `ruff check .` *(fails: 64 errors)*
- `python3 -m black --check .` *(fails: would reformat 13 files)*
- `python3 -m pytest -q` *(fails: missing deps such as aiofiles, fastapi)*
- `python3 -m pytest tests/test_vector_store_logging.py -q --noconftest`

### Risk
Low. Changes add supplemental logging without altering existing metrics or behavior.

------
https://chatgpt.com/codex/tasks/task_e_689657794858832aae951d5b1baaa222