### PR TITLE
Refresh similarity cutoff for memory lookups

### DIFF
--- a/app/memory/memory_store.py
+++ b/app/memory/memory_store.py
@@ -153,6 +153,7 @@ class MemoryVectorStore(VectorStore):
         return mem_id
 
     def query_user_memories(self, user_id: str, prompt: str, k: int = 5) -> List[str]:
+        self._dist_cutoff = 1.0 - _get_sim_threshold()
         logger.info(
             "query_user_memories start user_id=%s prompt=%s k=%s",
             user_id,


### PR DESCRIPTION
### Problem
`MemoryVectorStore.query_user_memories` only set the distance cutoff during initialization, so changes to the similarity threshold environment variable were ignored after startup.

### Solution
Refresh `self._dist_cutoff` using the latest `_get_sim_threshold()` at the start of each query while preserving the distance filter and `(dist, -timestamp)` ordering.

### Tests
`/usr/bin/python3 -m ruff check .` *(fails: multiple lint errors)*
`/usr/bin/python3 -m black --check .` *(fails: would reformat 14 files)*
`/usr/bin/python3 -m pytest -q` *(fails: missing dependencies such as rapidfuzz, httpx, fastapi, numpy, pydantic)*

### Risk
Low; recalculating the cutoff per call keeps behavior consistent but responsive to configuration changes.

------
https://chatgpt.com/codex/tasks/task_e_689668de4194832ab087b1bafa8f81e5