### PR TITLE
Clamp memory defaults

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,7 +119,7 @@ Skills are tried in the order defined in `app/skills/__init__.py`; first match w
 | `SBERT_MODEL` | `sentence-transformers/paraphrase-MiniLM-L3-v2` | no | Intent detection model |
 | `MODEL_ROUTER_HEAVY_WORDS` | `30` | no | Word count to trigger heavy model |
 | `MODEL_ROUTER_HEAVY_TOKENS` | `1000` | no | Token count to trigger heavy model |
-| `SIM_THRESHOLD` | `0.90` | no | Vector similarity cutoff |
+| `SIM_THRESHOLD` | `0.24` | no | Vector similarity cutoff |
 | `HOME_ASSISTANT_URL` | `http://localhost:8123` | no | Home Assistant base URL |
 | `HOME_ASSISTANT_TOKEN` | – | yes | HA long-lived token |
 | `LLAMA_EMBEDDINGS_MODEL` | – | yes* | Path to GGUF when using llama embeddings |

--- a/README.md
+++ b/README.md
@@ -62,7 +62,6 @@ Set environment variables as needed:
 | `PORT` | `8000` | no | Server port when running `python app/main.py` |
 | `SESSIONS_DIR` | `sessions/` | no | Base directory for session media |
 | `ADMIN_TOKEN` | – | no | Required to read `/config` |
-| `SIM_THRESHOLD` | `0.90` | no | Vector similarity cutoff |
 | `HOME_ASSISTANT_URL` | `http://localhost:8123` | no | Home Assistant base URL |
 | `HOME_ASSISTANT_TOKEN` | – | yes | HA long-lived token |
 | `INTENT_THRESHOLD` | `0.7` | no | Intent confidence cutoff |
@@ -75,7 +74,8 @@ Set environment variables as needed:
 | `NOTES_DB` | `notes.db` | no | SQLite file for notes skill |
 | `CALENDAR_FILE` | `data/calendar.json` | no | Calendar events source |
 | `MAX_UPLOAD_BYTES` | `10485760` | no | Max upload size for session media |
-| `MEM_TOP_K` | `5` | no | Memories returned from vector store |
+| `SIM_THRESHOLD` | `0.24` | no | Vector similarity cutoff |
+| `MEM_TOP_K` | `3` | no | Memories returned from vector store |
 | `DISABLE_QA_CACHE` | `false` | no | Skip semantic cache when set |
 | `VECTOR_STORE` | `chroma` | no | Vector store backend |
 | `USERS_DB` | `users.db` | no | SQLite path for auth users |

--- a/app/memory/env_utils.py
+++ b/app/memory/env_utils.py
@@ -20,9 +20,9 @@ def _env_flag(name: str) -> bool:
     return os.getenv(name, "").strip().lower() in {"1", "true", "yes", "on"}
 
 
-DEFAULT_SIM_THRESHOLD = 0.90
+DEFAULT_SIM_THRESHOLD = 0.24
 
-DEFAULT_MEM_TOP_K = 5
+DEFAULT_MEM_TOP_K = 3
 
 
 def _get_sim_threshold() -> float:
@@ -39,17 +39,18 @@ def _get_sim_threshold() -> float:
         )
         return DEFAULT_SIM_THRESHOLD
     if not 0.0 <= value <= 1.0:
+        clamped = min(max(value, 0.0), 1.0)
         logger.warning(
-            "SIM_THRESHOLD %.2f out of range [0, 1]; falling back to %.2f",
+            "SIM_THRESHOLD %.2f out of range [0, 1]; clamped to %.2f",
             value,
-            DEFAULT_SIM_THRESHOLD,
+            clamped,
         )
-        return DEFAULT_SIM_THRESHOLD
+        return clamped
     return value
 
 
 def _get_mem_top_k() -> int:
-    """Read the ``MEM_TOP_K`` env var with a default of 5."""
+    """Read the ``MEM_TOP_K`` env var with sane bounds."""
 
     raw = os.getenv("MEM_TOP_K", str(DEFAULT_MEM_TOP_K))
     try:
@@ -61,13 +62,14 @@ def _get_mem_top_k() -> int:
             DEFAULT_MEM_TOP_K,
         )
         return DEFAULT_MEM_TOP_K
-    if value <= 0:
+    if value < 1 or value > 10:
+        clamped = min(max(value, 1), 10)
         logger.warning(
-            "MEM_TOP_K %d must be positive; falling back to %d",
+            "MEM_TOP_K %d out of range [1, 10]; clamped to %d",
             value,
-            DEFAULT_MEM_TOP_K,
+            clamped,
         )
-        return DEFAULT_MEM_TOP_K
+        return clamped
     return value
 
 

--- a/app/status.py
+++ b/app/status.py
@@ -37,7 +37,7 @@ async def config(
     if not ADMIN_TOKEN or token != ADMIN_TOKEN:
         raise HTTPException(status_code=403, detail="forbidden")
     out = {k: v for k, v in os.environ.items() if k.isupper()}
-    out.setdefault("SIM_THRESHOLD", os.getenv("SIM_THRESHOLD", "0.90"))
+    out.setdefault("SIM_THRESHOLD", os.getenv("SIM_THRESHOLD", "0.24"))
     try:
         import builtins
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -17,7 +17,7 @@ def setup_app(monkeypatch):
 
     os.environ["OPENAI_API_KEY"] = "key"
     os.environ["OPENAI_MODEL"] = "gpt"
-    os.environ["SIM_THRESHOLD"] = "0.90"
+    os.environ["SIM_THRESHOLD"] = "0.24"
     import app.home_assistant as home_assistant
     import app.llama_integration as llama_integration
     import app.status as status
@@ -31,9 +31,11 @@ def setup_app(monkeypatch):
     monkeypatch.setattr(llama_integration, "startup_check", lambda: None)
     return main
 
+
 def test_key():
     print("👀 OPENAI_API_KEY =", os.getenv("OPENAI_API_KEY"))
     assert os.getenv("OPENAI_API_KEY", "").startswith("sk-")
+
 
 def test_config_forbidden(monkeypatch):
     main = setup_app(monkeypatch)
@@ -64,4 +66,4 @@ def test_config_env_reload(monkeypatch):
     assert resp.json()["DEBUG"] == "1"
     env.unlink()
     data = resp.json()
-    assert data["SIM_THRESHOLD"] == "0.90"
+    assert data["SIM_THRESHOLD"] == "0.24"

--- a/tests/test_memory_hygiene.py
+++ b/tests/test_memory_hygiene.py
@@ -34,7 +34,7 @@ async def config(token: str | None = Query(default=None)) -> dict:
     if not ADMIN_TOKEN or token != ADMIN_TOKEN:
         raise HTTPException(status_code=403, detail="forbidden")
     out = {k: v for k, v in os.environ.items() if k.isupper()}
-    out.setdefault("SIM_THRESHOLD", os.getenv("SIM_THRESHOLD", "0.90"))
+    out.setdefault("SIM_THRESHOLD", os.getenv("SIM_THRESHOLD", "0.24"))
     return out
 
 

--- a/tests/test_vector_store_threshold.py
+++ b/tests/test_vector_store_threshold.py
@@ -27,5 +27,6 @@ def test_threshold_out_of_range(monkeypatch, caplog):
     monkeypatch.setenv("SIM_THRESHOLD", "5")
     with caplog.at_level("WARNING"):
         store = ChromaVectorStore()
-    assert store._dist_cutoff == 1.0 - 0.90
+    # Out-of-range values are clamped to 1.0
+    assert store._dist_cutoff == 0.0
     assert "SIM_THRESHOLD" in caplog.text


### PR DESCRIPTION
### Problem
Similarity and memory retrieval defaults and environment handling needed tuning and stricter validation.

### Solution
- Lowered default SIM_THRESHOLD to 0.24 and MEM_TOP_K to 3.
- Added clamping and warning logic to `_get_sim_threshold` and `_get_mem_top_k`.
- Updated status/config endpoints, docs, and tests for new defaults.

### Tests
`PYENV_VERSION=3.11.12 python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'rapidfuzz')*
`PYENV_VERSION=3.11.12 ruff check .` *(fails: 63 errors)*
`PYENV_VERSION=3.11.12 black --check .` *(fails: would reformat app/embeddings.py, ...)*

### Risk
Low; changes are limited to configuration helpers and docs with minimal impact to runtime behaviour.

------
https://chatgpt.com/codex/tasks/task_e_689668aa4d3c832a86e2728ba5813ac9