### PR TITLE
Use cosine space for Chroma collections

### DIFF
--- a/app/memory/chroma_store.py
+++ b/app/memory/chroma_store.py
@@ -86,7 +86,7 @@ class ChromaVectorStore(VectorStore):
             base_cache = self._client.get_or_create_collection(
                 "qa_cache",
                 embedding_function=self._embedder,
-                metadata={"hnsw:space": "l2"},
+                metadata={"hnsw:space": "cosine"},
             )
         except TypeError:
             base_cache = self._client.get_or_create_collection(
@@ -97,7 +97,7 @@ class ChromaVectorStore(VectorStore):
             self._user_memories = self._client.get_or_create_collection(
                 "user_memories",
                 embedding_function=self._embedder,
-                metadata={"hnsw:space": "l2"},
+                metadata={"hnsw:space": "cosine"},
             )
         except TypeError:
             self._user_memories = self._client.get_or_create_collection(

--- a/tests/test_chroma_query_user_memories.py
+++ b/tests/test_chroma_query_user_memories.py
@@ -1,0 +1,22 @@
+from app.memory import chroma_store
+
+
+class _DummyCollection:
+    def query(self, *, query_texts, where, n_results, include):
+        return {
+            "documents": [["good", "bad", "another"]],
+            "distances": [[0.2, 0.6, 0.2]],
+            "metadatas": [[{"ts": 1}, {"ts": 2}, {"ts": 3}]],
+        }
+
+
+def test_query_user_memories_recomputes_and_sorts(monkeypatch):
+    store = object.__new__(chroma_store.ChromaVectorStore)
+    store._user_memories = _DummyCollection()
+    store._dist_cutoff = 0.0
+    monkeypatch.setattr(chroma_store, "_get_sim_threshold", lambda: 0.5)
+
+    res = store.query_user_memories("u", "prompt", k=5)
+
+    assert store._dist_cutoff == 0.5
+    assert res == ["another", "good"]


### PR DESCRIPTION
### Problem
Chroma collections were created using Euclidean distance, and `query_user_memories` needed regression coverage for its filtering and sort logic.

### Solution
- Create Chroma collections with `hnsw:space` set to `cosine`.
- Add a unit test that stubs the Chroma collection to ensure `query_user_memories` recomputes its distance cutoff and sorts results by `(distance, -timestamp)`.

### Tests
`pytest tests/test_chroma_query_user_memories.py::test_query_user_memories_recomputes_and_sorts -q` (missing dependency: aiosqlite)
`ruff check .` (63 errors)
`black --check .` (would reformat 14 files)

### Risk
Minimal; affects vector store initialization and adds isolated test.


------
https://chatgpt.com/codex/tasks/task_e_689668dde5cc832a829181164ff23ee8