### PR TITLE
Add vector store relevance regression test

### DIFF
--- a/tests/test_vector_store_relevance.py
+++ b/tests/test_vector_store_relevance.py
@@ -1,0 +1,16 @@
+import pytest
+from app.memory.vector_store import ChromaVectorStore, MemoryVectorStore
+
+
+@pytest.mark.parametrize("store_cls", [MemoryVectorStore, ChromaVectorStore])
+def test_unrelated_query_returns_empty(monkeypatch, tmp_path, store_cls):
+    monkeypatch.setenv("SIM_THRESHOLD", "0.99")
+    if store_cls is ChromaVectorStore:
+        pytest.importorskip("chromadb")
+        monkeypatch.setenv("CHROMA_PATH", str(tmp_path))
+    store = store_cls()
+    try:
+        store.add_user_memory("u", "hello world")
+        assert store.query_user_memories("u", "totally unrelated prompt") == []
+    finally:
+        store.close()


### PR DESCRIPTION
### Problem
No test covered vector store behavior when similarity threshold is very high, which could allow irrelevant memories to appear.

### Solution
Add a parametrized test ensuring both memory and chroma stores return no memories when `SIM_THRESHOLD` is set to `0.99` and the query is unrelated.

### Tests
`pytest -q` *(fails: openai package not installed, plus other assertion failures)*
`ruff check .` *(63 errors)*
`black --check .` *(would reformat 14 files)*

### Risk
Low. New test only; existing functionality unchanged. Additional dependencies or future threshold logic changes may require updating the test.


------
https://chatgpt.com/codex/tasks/task_e_689668def714832ab813f47df59fb1b5