### PR TITLE
Escalate routing for keyword and heavy intent prompts

### DIFF
--- a/tests/test_model_router.py
+++ b/tests/test_model_router.py
@@ -87,6 +87,18 @@ def test_route_text_ops_branches():
     assert d_complex.reason == "ops-complex"
 
 
+def test_route_text_keyword_escalates():
+    d = route_text(user_prompt="please summarize this", intent="chat")
+    assert d.model == "gpt-4.1-nano"
+    assert d.reason == "keyword"
+
+
+def test_route_text_heavy_intent_escalates():
+    d = route_text(user_prompt="hi", intent="analysis")
+    assert d.model == "gpt-4.1-nano"
+    assert d.reason == "heavy-intent"
+
+
 def test_route_vision_cap(monkeypatch):
     # Force a tiny cap via env; verify local-only after cap
     monkeypatch.setenv("VISION_MAX_IMAGES_PER_DAY", "1")


### PR DESCRIPTION
## Summary
- import keyword and heavy-intent sets in the model router
- escalate to `gpt-4.1-nano` when prompts contain known keywords or heavy intents
- test keyword and heavy-intent escalation branches

## Testing
- `ruff check .` *(fails: Found 110 errors)*
- `PYENV_VERSION=3.11.12 python -m pytest -q` *(fails: missing deps, interrupted during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68983f365774832a8ab4b92f05f4a5fb