### PR TITLE
Add embedding backend regression tests

### DIFF
--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -2,6 +2,7 @@ import os
 import sys
 import asyncio
 import logging
+import types
 import pytest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
@@ -30,10 +31,13 @@ class DummyLlama:
 
 
 def test_embed_openai(monkeypatch):
-    os.environ["EMBEDDING_BACKEND"] = "openai"
+    monkeypatch.setenv("EMBEDDING_BACKEND", "openai")
+    monkeypatch.setenv("VECTOR_STORE", "chroma")
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
     from app import embeddings
 
     monkeypatch.setattr(embeddings, "get_openai_client", lambda: DummyOpenAIClient())
+    embeddings._embed_openai_sync.cache_clear()
 
     res = asyncio.run(embeddings.embed("hi"))
     assert res == [1.0, 2.0, 3.0]
@@ -58,8 +62,10 @@ def test_embed_model_env(monkeypatch):
 
 
 def test_embed_llama(monkeypatch):
-    os.environ["EMBEDDING_BACKEND"] = "llama"
-    os.environ["LLAMA_EMBEDDINGS_MODEL"] = "/tmp/model.gguf"
+    monkeypatch.setenv("EMBEDDING_BACKEND", "llama")
+    monkeypatch.setenv("LLAMA_EMBEDDINGS_MODEL", "/tmp/model.gguf")
+    monkeypatch.setenv("VECTOR_STORE", "chroma")
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
     from app import embeddings
 
     monkeypatch.setattr(embeddings, "Llama", lambda *a, **k: DummyLlama())
@@ -88,16 +94,129 @@ def test_embedding_backend_logged(monkeypatch, caplog, backend):
     caplog.set_level(logging.DEBUG)
     if backend == "openai":
         monkeypatch.setenv("EMBEDDING_BACKEND", "openai")
+        monkeypatch.setenv("VECTOR_STORE", "chroma")
+        monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
         monkeypatch.setattr(embeddings, "get_openai_client", lambda: DummyOpenAIClient())
+        embeddings._embed_openai_sync.cache_clear()
         asyncio.run(embeddings.embed("hi"))
     elif backend == "llama":
         monkeypatch.setenv("EMBEDDING_BACKEND", "llama")
         monkeypatch.setenv("LLAMA_EMBEDDINGS_MODEL", "/tmp/model.gguf")
+        monkeypatch.setenv("VECTOR_STORE", "chroma")
+        monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
         monkeypatch.setattr(embeddings, "Llama", lambda *a, **k: DummyLlama())
         embeddings._llama_model = None
         asyncio.run(embeddings.embed("hi"))
     else:
         monkeypatch.setenv("EMBEDDING_BACKEND", "stub")
         embeddings.embed_sync("hi")
+    assert f"backend={backend}" in caplog.text
 
-    assert f"Embedding backend: {backend}" in caplog.text
+
+@pytest.mark.parametrize("func", ["embed_sync", "embed"])
+def test_force_stub_pytest(monkeypatch, func):
+    monkeypatch.setenv("EMBEDDING_BACKEND", "openai")
+    from app import embeddings
+
+    def boom():
+        raise RuntimeError("should not call openai")
+
+    monkeypatch.setattr(embeddings, "get_openai_client", boom)
+    expected = embeddings._embed_stub("hi")
+    if func == "embed_sync":
+        res = embeddings.embed_sync("hi")
+    else:
+        res = asyncio.run(embeddings.embed("hi"))
+    assert res == expected
+
+
+@pytest.mark.parametrize("func", ["embed_sync", "embed"])
+def test_force_stub_memory(monkeypatch, func):
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+    monkeypatch.setenv("VECTOR_STORE", "memory")
+    monkeypatch.setenv("EMBEDDING_BACKEND", "openai")
+    from app import embeddings
+
+    def boom():
+        raise RuntimeError("should not call openai")
+
+    monkeypatch.setattr(embeddings, "get_openai_client", boom)
+    expected = embeddings._embed_stub("hi")
+    if func == "embed_sync":
+        res = embeddings.embed_sync("hi")
+    else:
+        res = asyncio.run(embeddings.embed("hi"))
+    assert res == expected
+
+
+def test_openai_cache_ttl(monkeypatch):
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+    monkeypatch.setenv("VECTOR_STORE", "chroma")
+    monkeypatch.setenv("EMBEDDING_BACKEND", "openai")
+    from app import embeddings
+
+    class DummyClient:
+        def __init__(self):
+            self.calls = 0
+            self.embeddings = self
+
+        def create(self, model, input, encoding_format="float"):
+            self.calls += 1
+            return types.SimpleNamespace(data=[types.SimpleNamespace(embedding=[0.0] * 8)])
+
+    dummy = DummyClient()
+    monkeypatch.setattr(embeddings, "get_openai_client", lambda: dummy)
+    embeddings._embed_openai_sync.cache_clear()
+    monkeypatch.setattr(embeddings, "_TTL", 1)
+    t = 0
+
+    def fake_time():
+        return t
+
+    monkeypatch.setattr(embeddings.time, "time", fake_time)
+
+    asyncio.run(embeddings.embed("hi"))
+    asyncio.run(embeddings.embed("hi"))
+    assert dummy.calls == 1
+
+    t = 2
+    asyncio.run(embeddings.embed("hi"))
+    assert dummy.calls == 2
+
+
+def test_llama_missing_dependency(monkeypatch):
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+    monkeypatch.setenv("VECTOR_STORE", "chroma")
+    monkeypatch.setenv("EMBEDDING_BACKEND", "llama")
+    from app import embeddings
+
+    monkeypatch.setattr(embeddings, "Llama", None)
+    embeddings._llama_model = None
+    with pytest.raises(RuntimeError) as exc:
+        embeddings.embed_sync("hi")
+    assert "llama-cpp-python not installed" in str(exc.value)
+
+
+def test_llama_missing_model(monkeypatch):
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+    monkeypatch.setenv("VECTOR_STORE", "chroma")
+    monkeypatch.setenv("EMBEDDING_BACKEND", "llama")
+    from app import embeddings
+
+    monkeypatch.setattr(embeddings, "Llama", lambda *a, **k: DummyLlama())
+    monkeypatch.delenv("LLAMA_EMBEDDINGS_MODEL", raising=False)
+    embeddings._llama_model = None
+    with pytest.raises(RuntimeError) as exc:
+        embeddings.embed_sync("hi")
+    assert "Missing LLAMA_EMBEDDINGS_MODEL" in str(exc.value)
+
+
+def test_stub_deterministic(monkeypatch):
+    monkeypatch.setenv("EMBEDDING_BACKEND", "stub")
+    from app import embeddings
+
+    v1 = embeddings.embed_sync("hello")
+    v2 = embeddings.embed_sync("hello")
+    v3 = asyncio.run(embeddings.embed("hello"))
+    assert len(v1) == 8
+    assert v1 == v2 == v3


### PR DESCRIPTION
## Summary
- add regression tests for embedding backends
- cover OpenAI TTL cache, LLaMA error handling, and stub determinism

## Testing
- `/root/.pyenv/versions/3.11.12/bin/python -m pytest tests/test_embeddings.py -q`
- `/root/.pyenv/versions/3.11.12/bin/python -m pytest -q` *(fails: ImportError: cannot import name 'ChromaVectorStore' from 'app.memory.vector_store')*


------
https://chatgpt.com/codex/tasks/task_e_689846a46820832ab60a96d21952ca0c