### PR TITLE
Add OpenVoice voice synthesis adapter stub

### DIFF
--- a/app/adapters/__init__.py
+++ b/app/adapters/__init__.py
@@ -1,0 +1,1 @@
+"""External service adapters."""

--- a/app/adapters/voice/__init__.py
+++ b/app/adapters/voice/__init__.py
@@ -1,0 +1,5 @@
+"""Voice synthesis adapters."""
+
+from .openvoice_adapter import VoiceSynth
+
+__all__ = ["VoiceSynth"]

--- a/app/adapters/voice/openvoice_adapter.py
+++ b/app/adapters/voice/openvoice_adapter.py
@@ -1,0 +1,39 @@
+"""OpenVoice/Piper text-to-speech adapter.
+
+This module defines the :class:`VoiceSynth` interface for cloning voices and
+synthesizing speech. The actual model loading and synthesis are intentionally
+left unimplemented; this is only the API surface.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Dict
+
+logger = logging.getLogger(__name__)
+
+
+class VoiceSynth:
+    """Basic interface for text-to-speech synthesis."""
+
+    def __init__(self, voice_profile_path: str):
+        """Initialize the synthesizer.
+
+        Parameters
+        ----------
+        voice_profile_path:
+            Path to a ``.pt`` file containing the speaker profile or embedding.
+        """
+        self.voice_profile_path = Path(voice_profile_path)
+
+    def speak(self, text: str, *, style: Dict | None = None) -> bytes:
+        """Return WAV audio bytes for ``text``.
+
+        ``style`` may include parameters like pitch or rate. This stub does not
+        perform any synthesis.
+        """
+        raise NotImplementedError("Voice synthesis not implemented yet")
+
+
+__all__ = ["VoiceSynth"]


### PR DESCRIPTION
## Summary
- create `VoiceSynth` interface for future OpenVoice/Piper text-to-speech support
- expose new adapter under `app.adapters.voice`

## Testing
- `PYENV_VERSION=3.11.12 ruff check app/adapters/__init__.py app/adapters/voice/__init__.py app/adapters/voice/openvoice_adapter.py`
- `PYENV_VERSION=3.11.12 pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic', 'fastapi', ...)*

------
https://chatgpt.com/codex/tasks/task_e_68984a42e8f0832aa69e3601b8086601