### PR TITLE
Add traffic skill for driving time

### DIFF
--- a/app/skills/__init__.py
+++ b/app/skills/__init__.py
@@ -20,6 +20,7 @@ from .cover_skill import CoverSkill
 from .fan_skill import FanSkill
 from .notify_skill import NotifySkill
 from .search_skill import SearchSkill
+from .traffic_skill import TrafficSkill
 from .translate_skill import TranslateSkill
 from .news_skill import NewsSkill
 from .joke_skill import JokeSkill
@@ -55,6 +56,7 @@ SKILL_CLASSES: list[type] = [
     FanSkill,
     NotifySkill,
     SearchSkill,
+    TrafficSkill,
     TranslateSkill,
     NewsSkill,
     JokeSkill,

--- a/app/skills/traffic_skill.py
+++ b/app/skills/traffic_skill.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import os
+import re
+import logging
+from typing import Tuple
+
+import httpx
+
+from .base import Skill
+
+log = logging.getLogger(__name__)
+
+DEFAULT_ORIGIN = os.getenv("CITY_NAME", "Detroit,US")
+GEOCODE_URL = "https://nominatim.openstreetmap.org/search"
+ROUTE_URL = "https://router.project-osrm.org/route/v1/driving"
+
+
+class TrafficSkill(Skill):
+    PATTERNS = [
+        re.compile(r"traffic to ([\w\s,]+)", re.I),
+        re.compile(r"how long to drive to ([\w\s,]+)", re.I),
+    ]
+
+    async def _geocode(
+        self, client: httpx.AsyncClient, place: str
+    ) -> Tuple[float, float] | None:
+        resp = await client.get(
+            GEOCODE_URL,
+            params={"q": place, "format": "json", "limit": 1},
+            headers={"User-Agent": "GesahniV2"},
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        if not data:
+            return None
+        return float(data[0]["lat"]), float(data[0]["lon"])
+
+    async def run(self, prompt: str, match: re.Match) -> str:
+        dest = match.group(1).strip()
+        origin = DEFAULT_ORIGIN
+        try:
+            async with httpx.AsyncClient(timeout=10) as client:
+                orig = await self._geocode(client, origin)
+                destc = await self._geocode(client, dest)
+                if not orig or not destc:
+                    return f"Couldn't find route to {dest}."
+                o_lat, o_lon = orig
+                d_lat, d_lon = destc
+                resp = await client.get(
+                    f"{ROUTE_URL}/{o_lon},{o_lat};{d_lon},{d_lat}",
+                    params={"overview": "false"},
+                )
+                resp.raise_for_status()
+                data = resp.json()
+                duration = data.get("routes", [{}])[0].get("duration")
+                if duration is None:
+                    return f"Couldn't get traffic info for {dest}."
+        except Exception:
+            log.exception("traffic lookup failed")
+            return f"Couldn't get traffic info for {dest}."
+        minutes = int(duration / 60)
+        return f"Driving to {dest.title()} takes about {minutes} minutes."

--- a/tests/test_skills/test_traffic_skill.py
+++ b/tests/test_skills/test_traffic_skill.py
@@ -1,0 +1,79 @@
+import asyncio
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+os.environ.setdefault("OLLAMA_URL", "http://x")
+os.environ.setdefault("OLLAMA_MODEL", "llama3")
+os.environ.setdefault("HOME_ASSISTANT_URL", "http://ha")
+os.environ.setdefault("HOME_ASSISTANT_TOKEN", "token")
+os.environ.setdefault("CITY_NAME", "Detroit,US")
+
+import httpx
+from app.skills.traffic_skill import TrafficSkill
+
+
+class BaseClient:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+
+class AnnArborClient(BaseClient):
+    async def get(self, url, params=None, headers=None):
+        class R:
+            def __init__(self, data):
+                self._data = data
+
+            def json(self):
+                return self._data
+
+            def raise_for_status(self):
+                pass
+
+        if "nominatim" in url:
+            q = params["q"]
+            if q == "Detroit,US":
+                return R([{"lat": "42.3314", "lon": "-83.0458"}])
+            return R([{"lat": "42.2808", "lon": "-83.7430"}])
+        return R({"routes": [{"duration": 3600}]})
+
+
+class ChicagoClient(BaseClient):
+    async def get(self, url, params=None, headers=None):
+        class R:
+            def __init__(self, data):
+                self._data = data
+
+            def json(self):
+                return self._data
+
+            def raise_for_status(self):
+                pass
+
+        if "nominatim" in url:
+            q = params["q"]
+            if q == "Detroit,US":
+                return R([{"lat": "42.3314", "lon": "-83.0458"}])
+            return R([{"lat": "41.8781", "lon": "-87.6298"}])
+        return R({"routes": [{"duration": 7200}]})
+
+
+def test_traffic_ann_arbor(monkeypatch):
+    monkeypatch.setattr(httpx, "AsyncClient", lambda timeout=10: AnnArborClient())
+    skill = TrafficSkill()
+    m = skill.match("traffic to ann arbor")
+    resp = asyncio.run(skill.run("traffic to ann arbor", m))
+    assert "Ann Arbor" in resp
+    assert "60 minutes" in resp
+
+
+def test_drive_to_chicago(monkeypatch):
+    monkeypatch.setattr(httpx, "AsyncClient", lambda timeout=10: ChicagoClient())
+    skill = TrafficSkill()
+    m = skill.match("how long to drive to Chicago")
+    resp = asyncio.run(skill.run("how long to drive to Chicago", m))
+    assert "Chicago" in resp
+    assert "120 minutes" in resp


### PR DESCRIPTION
## Summary
- add `TrafficSkill` to retrieve driving time using OpenStreetMap Nominatim and OSRM
- register `TrafficSkill` in skill registry
- test traffic skill with mocked mapping API responses

## Testing
- `ruff check app/skills/traffic_skill.py tests/test_skills/test_traffic_skill.py`
- `python3 -m black app/skills/traffic_skill.py tests/test_skills/test_traffic_skill.py`
- `python3 -m pytest tests/test_skills/test_traffic_skill.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68984d046e94832a86cc4fbc715a0858