### PR TITLE
Add sports skill for team results and schedules

### DIFF
--- a/app/skills/__init__.py
+++ b/app/skills/__init__.py
@@ -33,6 +33,7 @@ from .climate_skill import ClimateSkill
 from .vacuum_skill import VacuumSkill
 from .notes_skill import NotesSkill
 from .status_skill import StatusSkill
+from .sports_skill import SportsSkill
 
 # Preserve class order but avoid duplicates when this module reloads
 SKILL_CLASSES: list[type] = [
@@ -68,6 +69,7 @@ SKILL_CLASSES: list[type] = [
     VacuumSkill,
     NotesSkill,
     StatusSkill,
+    SportsSkill,
 ]
 
 _base.SKILLS.clear()

--- a/app/skills/sports_skill.py
+++ b/app/skills/sports_skill.py
@@ -1,0 +1,83 @@
+# app/skills/sports_skill.py
+from __future__ import annotations
+
+import re
+
+import httpx
+
+from .base import Skill
+
+
+WIN_PATTERN = re.compile(r"did the (?P<team>[\w\s]+) win", re.I)
+NEXT_PATTERN = re.compile(r"next game for (?P<team>[\w\s]+)", re.I)
+
+
+class SportsSkill(Skill):
+    PATTERNS = [WIN_PATTERN, NEXT_PATTERN]
+
+    async def run(self, prompt: str, match: re.Match) -> str:
+        team = match.group("team").strip()
+        async with httpx.AsyncClient(timeout=5.0) as client:
+            search = await client.get(
+                "https://www.thesportsdb.com/api/v1/json/3/searchteams.php",
+                params={"t": team},
+            )
+            search.raise_for_status()
+            data = search.json()
+            teams = data.get("teams")
+            if not teams:
+                return f"I couldn't find a team named {team}."
+            team_info = teams[0]
+            team_id = team_info["idTeam"]
+            team_name = team_info["strTeam"]
+
+            if match.re is WIN_PATTERN:
+                last_resp = await client.get(
+                    "https://www.thesportsdb.com/api/v1/json/3/eventslast.php",
+                    params={"id": team_id},
+                )
+                last_resp.raise_for_status()
+                results = last_resp.json().get("results")
+                if not results:
+                    return f"No recent games found for {team_name}."
+                last = results[0]
+                home = last["strHomeTeam"]
+                away = last["strAwayTeam"]
+                home_score = last["intHomeScore"]
+                away_score = last["intAwayScore"]
+                if home_score is None or away_score is None:
+                    return f"No score data found for {team_name}."
+                home_score = int(home_score)
+                away_score = int(away_score)
+                if home == team_name:
+                    win = home_score > away_score
+                    opponent = away
+                    team_score = home_score
+                    opp_score = away_score
+                else:
+                    win = away_score > home_score
+                    opponent = home
+                    team_score = away_score
+                    opp_score = home_score
+                result = "won" if win else "lost"
+                return (
+                    f"The {team_name} {result} {team_score}-{opp_score} against the {opponent}."
+                )
+
+            next_resp = await client.get(
+                "https://www.thesportsdb.com/api/v1/json/3/eventsnext.php",
+                params={"id": team_id},
+            )
+            next_resp.raise_for_status()
+            events = next_resp.json().get("events")
+            if not events:
+                return f"No upcoming games found for {team_name}."
+            nxt = events[0]
+            home = nxt["strHomeTeam"]
+            away = nxt["strAwayTeam"]
+            opponent = away if home == team_name else home
+            date = nxt.get("dateEvent")
+            time = nxt.get("strTime")
+            return (
+                f"The next game for the {team_name} is against the {opponent} on {date} at {time}."
+            )

--- a/tests/test_skills/test_sports_skill.py
+++ b/tests/test_skills/test_sports_skill.py
@@ -1,0 +1,119 @@
+import asyncio
+import os
+import sys
+import importlib.util
+import types
+from pathlib import Path
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+
+import httpx
+
+repo_root = Path(__file__).resolve().parents[2]
+app_pkg = types.ModuleType("app")
+app_pkg.__path__ = [str(repo_root / "app")]
+sys.modules["app"] = app_pkg
+skills_pkg = types.ModuleType("app.skills")
+skills_pkg.__path__ = [str(repo_root / "app" / "skills")]
+sys.modules["app.skills"] = skills_pkg
+
+router_stub = types.ModuleType("app.router")
+router_stub.llama_circuit_open = False
+router_stub.LLAMA_HEALTHY = True
+sys.modules["app.router"] = router_stub
+model_picker_stub = types.ModuleType("app.model_picker")
+model_picker_stub.LLAMA_HEALTHY = True
+sys.modules["app.model_picker"] = model_picker_stub
+
+llama_stub = types.ModuleType("app.llama_integration")
+llama_stub.LLAMA_HEALTHY = True
+sys.modules["app.llama_integration"] = llama_stub
+
+base_path = repo_root / "app" / "skills" / "base.py"
+base_spec = importlib.util.spec_from_file_location("app.skills.base", base_path)
+base_module = importlib.util.module_from_spec(base_spec)
+base_spec.loader.exec_module(base_module)
+sys.modules["app.skills.base"] = base_module
+
+sports_path = repo_root / "app" / "skills" / "sports_skill.py"
+sports_spec = importlib.util.spec_from_file_location("app.skills.sports_skill", sports_path)
+sports_module = importlib.util.module_from_spec(sports_spec)
+sports_spec.loader.exec_module(sports_module)
+SportsSkill = sports_module.SportsSkill
+
+
+class FakeResponse:
+    def __init__(self, data):
+        self._data = data
+
+    def json(self):
+        return self._data
+
+    def raise_for_status(self):
+        pass
+
+
+class FakeClient:
+    def __init__(self, responses):
+        self._responses = responses
+        self._index = 0
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+    async def get(self, url, params=None):
+        resp = self._responses[self._index]
+        self._index += 1
+        return resp
+
+
+def test_did_team_win(monkeypatch):
+    responses = [
+        FakeResponse({"teams": [{"idTeam": "1", "strTeam": "Example FC"}]}),
+        FakeResponse(
+            {
+                "results": [
+                    {
+                        "strHomeTeam": "Example FC",
+                        "strAwayTeam": "Rivals FC",
+                        "intHomeScore": "3",
+                        "intAwayScore": "1",
+                    }
+                ]
+            }
+        ),
+    ]
+    monkeypatch.setattr(httpx, "AsyncClient", lambda **kw: FakeClient(responses))
+    skill = SportsSkill()
+    m = skill.match("did the Example FC win")
+    out = asyncio.run(skill.run("did the Example FC win", m))
+    assert "Example FC won 3-1" in out
+    assert "Rivals FC" in out
+
+
+def test_next_game(monkeypatch):
+    responses = [
+        FakeResponse({"teams": [{"idTeam": "1", "strTeam": "Example FC"}]}),
+        FakeResponse(
+            {
+                "events": [
+                    {
+                        "strHomeTeam": "Example FC",
+                        "strAwayTeam": "Rivals FC",
+                        "dateEvent": "2025-06-01",
+                        "strTime": "19:00:00",
+                    }
+                ]
+            }
+        ),
+    ]
+    monkeypatch.setattr(httpx, "AsyncClient", lambda **kw: FakeClient(responses))
+    skill = SportsSkill()
+    m = skill.match("next game for Example FC")
+    out = asyncio.run(skill.run("next game for Example FC", m))
+    assert "next game for the Example FC" in out
+    assert "Rivals FC" in out
+    assert "2025-06-01" in out


### PR DESCRIPTION
## Summary
- add SportsSkill for checking if a team won or when it plays next using TheSportsDB API
- register SportsSkill in the skill registry
- cover win and next-game scenarios with mocked API tests

## Testing
- `python3 -m ruff check app/skills/sports_skill.py app/skills/__init__.py tests/test_skills/test_sports_skill.py`
- `python3 -m pytest tests/test_skills/test_sports_skill.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68984d08bb10832a921cf3dc675c976c