### PR TITLE
Add basic alarm skill with scheduling and cancel tests

### DIFF
--- a/app/skills/__init__.py
+++ b/app/skills/__init__.py
@@ -8,6 +8,7 @@ from .weather_skill import WeatherSkill
 from .forecast_skill import ForecastSkill
 from .reminder_skill import ReminderSkill
 from .timer_skill import TimerSkill
+from .alarm_skill import AlarmSkill
 from .math_skill import MathSkill
 from .unit_conversion_skill import UnitConversionSkill
 from .currency_skill import CurrencySkill
@@ -43,6 +44,7 @@ SKILL_CLASSES: list[type] = [
     ForecastSkill,
     ReminderSkill,
     TimerSkill,
+    AlarmSkill,
     MathSkill,
     UnitConversionSkill,
     CurrencySkill,

--- a/app/skills/alarm_skill.py
+++ b/app/skills/alarm_skill.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import json
+import os
+import re
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Dict
+
+from .base import Skill
+from .reminder_skill import scheduler
+
+_ALARMS_PATH = Path(os.getenv("ALARMS_STORE", "data/alarms.json"))
+ALARMS: Dict[str, str] = {}
+
+if _ALARMS_PATH.exists():
+    try:
+        data = json.loads(_ALARMS_PATH.read_text(encoding="utf-8") or "{}")
+        if isinstance(data, dict):
+            ALARMS.update({str(k): str(v) for k, v in data.items()})
+    except Exception:
+        pass
+
+
+def _persist_alarms() -> None:
+    try:
+        _ALARMS_PATH.parent.mkdir(parents=True, exist_ok=True)
+        _ALARMS_PATH.write_text(
+            json.dumps(ALARMS, ensure_ascii=False, indent=2), encoding="utf-8"
+        )
+    except Exception:
+        pass
+
+
+def _parse_time(t: str) -> datetime | None:
+    m = re.match(r"(\d{1,2})(?::(\d{2}))?\s*(am|pm)", t, re.I)
+    if not m:
+        return None
+    hr = int(m.group(1))
+    mn = int(m.group(2) or 0)
+    ampm = m.group(3).lower()
+    if ampm == "pm" and hr < 12:
+        hr += 12
+    if ampm == "am" and hr == 12:
+        hr = 0
+    now = datetime.now()
+    run_dt = now.replace(hour=hr, minute=mn, second=0, microsecond=0)
+    if run_dt <= now:
+        run_dt += timedelta(days=1)
+    return run_dt
+
+
+class AlarmSkill(Skill):
+    PATTERNS = [
+        re.compile(r"set alarm for (?P<time>\d{1,2}(?::\d{2})?\s*(?:am|pm))", re.I),
+        re.compile(
+            r"cancel alarm(?: for (?P<ctime>\d{1,2}(?::\d{2})?\s*(?:am|pm)))", re.I
+        ),
+        re.compile(r"(?:list|show) alarms", re.I),
+    ]
+
+    async def run(self, prompt: str, match: re.Match) -> str:
+        if not scheduler.running:
+            scheduler.start()
+        gd = match.groupdict()
+
+        if gd.get("time"):
+            run_dt = _parse_time(gd["time"])  # type: ignore[arg-type]
+            if not run_dt:
+                return "Could not parse time."
+            time_str = run_dt.strftime("%I:%M %p")
+            job = scheduler.add_job(lambda: None, "date", run_date=run_dt)
+            job_id = getattr(job, "id", str(job))
+            ALARMS[time_str] = str(job_id)
+            _persist_alarms()
+            return f"Alarm set for {time_str}."
+
+        if gd.get("ctime"):
+            run_dt = _parse_time(gd["ctime"])  # type: ignore[arg-type]
+            if not run_dt:
+                return "Could not parse time."
+            time_str = run_dt.strftime("%I:%M %p")
+            job_id = ALARMS.pop(time_str, None)
+            if not job_id:
+                return "No such alarm."
+            try:
+                scheduler.remove_job(job_id)  # type: ignore[attr-defined]
+            except Exception:
+                pass
+            _persist_alarms()
+            return f"Alarm for {time_str} cancelled."
+
+        if ALARMS:
+            times = ", ".join(sorted(ALARMS.keys()))
+            return f"Alarms set for {times}."
+        return "No alarms set."

--- a/tests/test_skills/test_alarm_skill.py
+++ b/tests/test_skills/test_alarm_skill.py
@@ -1,0 +1,33 @@
+import asyncio
+import os
+import sys
+import tempfile
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+os.environ.setdefault("OLLAMA_URL", "http://x")
+os.environ.setdefault("OLLAMA_MODEL", "llama3")
+os.environ.setdefault("HOME_ASSISTANT_URL", "http://ha")
+os.environ.setdefault("HOME_ASSISTANT_TOKEN", "token")
+
+os.environ["ALARMS_STORE"] = tempfile.mkstemp()[1]
+
+from app.skills.alarm_skill import AlarmSkill
+
+
+def test_alarm_set_list_cancel():
+    skill = AlarmSkill()
+    m1 = skill.match("set alarm for 7am")
+    resp1 = asyncio.run(skill.run("set alarm for 7am", m1))
+    assert "07:00 AM" in resp1
+
+    m2 = skill.match("list alarms")
+    resp2 = asyncio.run(skill.run("list alarms", m2))
+    assert "07:00 AM" in resp2
+
+    m3 = skill.match("cancel alarm for 7am")
+    resp3 = asyncio.run(skill.run("cancel alarm for 7am", m3))
+    assert "cancelled" in resp3.lower()
+
+    m4 = skill.match("list alarms")
+    resp4 = asyncio.run(skill.run("list alarms", m4))
+    assert "no alarms" in resp4.lower()


### PR DESCRIPTION
## Summary
- add `AlarmSkill` for setting, listing, and canceling alarms
- register `AlarmSkill` in skill registry
- test alarm set/list/cancel behavior

## Testing
- `PYENV_VERSION=3.11.12 ruff check app/skills/alarm_skill.py tests/test_skills/test_alarm_skill.py app/skills/__init__.py`
- `PYENV_VERSION=3.11.12 pytest tests/test_skills/test_alarm_skill.py -q`
- `PYENV_VERSION=3.11.12 pytest -q` *(fails: ImportError: No module named 'aiofiles', AttributeError: '_APIRouter' object has no attribute 'post')*

------
https://chatgpt.com/codex/tasks/task_e_68984d01b8fc832ab128efd7bc5af517