### PR TITLE
Track input and output token costs

### DIFF
--- a/app/metrics.py
+++ b/app/metrics.py
@@ -34,7 +34,7 @@ REQUEST_LATENCY = Histogram(
 REQUEST_COST = Histogram(
     "app_request_cost_usd",
     "Request cost in USD",
-    ["endpoint", "method", "engine"],
+    ["endpoint", "method", "engine", "segment"],
 )
 
 # Counter for LLaMA prompt/completion tokens

--- a/app/middleware.py
+++ b/app/middleware.py
@@ -3,7 +3,6 @@ import asyncio
 import time
 import os
 from hashlib import sha256
-from typing import Set
 
 from fastapi import Request, Response
 from starlette.middleware.base import BaseHTTPMiddleware
@@ -122,9 +121,17 @@ async def trace_request(request: Request, call_next):
         metrics.REQUEST_LATENCY.labels(
             request.url.path, request.method, engine
         ).observe(rec.latency_ms / 1000)
+        if rec.prompt_cost_usd:
+            metrics.REQUEST_COST.labels(
+                request.url.path, request.method, engine, "prompt"
+            ).observe(rec.prompt_cost_usd)
+        if rec.completion_cost_usd:
+            metrics.REQUEST_COST.labels(
+                request.url.path, request.method, engine, "completion"
+            ).observe(rec.completion_cost_usd)
         if rec.cost_usd:
             metrics.REQUEST_COST.labels(
-                request.url.path, request.method, engine
+                request.url.path, request.method, engine, "total"
             ).observe(rec.cost_usd)
 
         if isinstance(response, Response):

--- a/app/telemetry.py
+++ b/app/telemetry.py
@@ -49,6 +49,8 @@ class LogRecord(BaseModel):
     model_name: Optional[str] = None
     prompt_tokens: Optional[int] = None
     completion_tokens: Optional[int] = None
+    prompt_cost_usd: Optional[float] = None
+    completion_cost_usd: Optional[float] = None
     cost_usd: Optional[float] = None
 
     # home assistant audit

--- a/tests/test_gpt_client_cost.py
+++ b/tests/test_gpt_client_cost.py
@@ -1,0 +1,45 @@
+import pytest
+
+from app import gpt_client
+from app.telemetry import LogRecord, log_record_var
+
+
+class _Usage:
+    prompt_tokens = 1000
+    completion_tokens = 2000
+
+
+class _Resp:
+    choices = [type("C", (), {"message": type("M", (), {"content": "hi"})()})]
+    usage = _Usage()
+
+
+class _Completions:
+    async def create(self, *args, **kwargs):
+        return _Resp()
+
+
+class _Chat:
+    completions = _Completions()
+
+
+class _Client:
+    chat = _Chat()
+
+
+@pytest.mark.asyncio
+async def test_cost_breakdown(monkeypatch):
+    monkeypatch.setattr(gpt_client, "_TEST_MODE", False)
+    monkeypatch.setattr(gpt_client, "get_client", lambda: _Client())
+    rec = LogRecord(req_id="1")
+    token = log_record_var.set(rec)
+    try:
+        _, pt, ct, cost = await gpt_client.ask_gpt("hi", model="gpt-4o")
+    finally:
+        log_record_var.reset(token)
+    assert pt == 1000
+    assert ct == 2000
+    assert cost == pytest.approx(0.035)
+    assert rec.prompt_cost_usd == pytest.approx(0.005)
+    assert rec.completion_cost_usd == pytest.approx(0.03)
+    assert rec.cost_usd == pytest.approx(0.035)

--- a/tests/test_metrics_endpoint.py
+++ b/tests/test_metrics_endpoint.py
@@ -1,4 +1,5 @@
-import sys, os
+import os
+import sys
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 from fastapi.testclient import TestClient
@@ -20,6 +21,7 @@ def test_metrics_endpoint(monkeypatch):
         rec = log_record_var.get()
         if rec:
             rec.engine_used = "gpt"
+            rec.prompt_cost_usd = 0.1
             rec.cost_usd = 0.1
         return "ok"
 


### PR DESCRIPTION
## Summary
- track separate input and output token rates per model
- record prompt and completion costs in telemetry and metrics
- add unit test covering cost breakdown

## Testing
- `PYENV_VERSION=3.11.12 ruff check app/gpt_client.py app/telemetry.py app/metrics.py app/middleware.py tests/test_metrics_endpoint.py tests/test_gpt_client_cost.py`
- `PYENV_VERSION=3.11.12 python -m pytest -q` *(fails: Interrupted: 53 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_689927268050832a9e0e1be505f53ea1