### PR TITLE
Use auth dependency for Google integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ curl -X POST localhost:8000/logout -H "Authorization: Bearer <refresh_token>"
 * `/healthz`: unauthenticated health probe.
 * `/config`: view config.
 * `/intent-test`: debug your prompt intent.
+* Google integration endpoints such as `/google/auth/url`, `/google/oauth/callback`, `/google/gmail/send`, and `/google/calendar/create` require an authenticated user session. OAuth credentials are stored per user.
 
 Note: all endpoints are also available under the `/v1` prefix.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,7 @@ filelock==3.18.0
 flatbuffers==25.2.10
 fsspec==2025.7.0
 google-auth==2.40.3
+google-auth-oauthlib==1.2.0
 googleapis-common-protos==1.70.0
 grpcio==1.74.0
 h11==0.16.0

--- a/tests/test_google_oauth.py
+++ b/tests/test_google_oauth.py
@@ -1,0 +1,83 @@
+import sys
+from datetime import datetime, timezone
+
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
+
+from app.deps.user import get_current_user_id
+
+
+def _client(tmp_path, monkeypatch):
+    db_path = tmp_path / "google.sqlite3"
+    monkeypatch.setenv("GOOGLE_CLIENT_ID", "cid")
+    monkeypatch.setenv("GOOGLE_CLIENT_SECRET", "csecret")
+    monkeypatch.setenv("GOOGLE_OAUTH_DB_URL", f"sqlite:///{db_path}")
+
+    # reload modules to pick up env vars
+    for mod in list(sys.modules):
+        if mod.startswith("app.integrations.google"):
+            del sys.modules[mod]
+
+    from importlib import import_module
+
+    routes = import_module("app.integrations.google.routes")
+
+    app = FastAPI()
+    app.include_router(routes.router, prefix="/google")
+    client = TestClient(app)
+    client.__enter__()
+    return client, routes
+
+
+def _override(user_id: str):
+    def _inner(request: Request = None):
+        if request is not None:
+            request.state.user_id = user_id
+        return user_id
+
+    return _inner
+
+
+def test_oauth_flow_two_users(tmp_path, monkeypatch):
+    client, routes = _client(tmp_path, monkeypatch)
+
+    # stub out Google OAuth interactions
+    monkeypatch.setattr(routes, "build_auth_url", lambda uid: (f"http://auth/{uid}", f"state-{uid}"))
+    monkeypatch.setattr(routes, "exchange_code", lambda code, state: code)
+
+    def fake_creds_to_record(code: str):
+        return {
+            "access_token": f"access-{code}",
+            "refresh_token": f"refresh-{code}",
+            "token_uri": "uri",
+            "client_id": "cid",
+            "client_secret": "secret",
+            "scopes": "s1 s2",
+            "expiry": datetime.now(timezone.utc),
+        }
+
+    monkeypatch.setattr(routes, "creds_to_record", fake_creds_to_record)
+
+    # user1 flow
+    client.app.dependency_overrides[get_current_user_id] = _override("user1")
+    r1 = client.get("/google/auth/url")
+    assert r1.json()["auth_url"] == "http://auth/user1"
+    cb1 = client.get("/google/oauth/callback", params={"code": "c1", "state": "state-user1"})
+    assert cb1.status_code == 200
+    s1 = client.get("/google/status")
+    assert s1.json()["linked"] is True
+
+    # user2 flow
+    client.app.dependency_overrides[get_current_user_id] = _override("user2")
+    r2 = client.get("/google/auth/url")
+    assert r2.json()["auth_url"] == "http://auth/user2"
+    cb2 = client.get("/google/oauth/callback", params={"code": "c2", "state": "state-user2"})
+    assert cb2.status_code == 200
+    s2 = client.get("/google/status")
+    assert s2.json()["linked"] is True
+
+    with routes.SessionLocal() as s:
+        row1 = s.get(routes.GoogleToken, "user1")
+        row2 = s.get(routes.GoogleToken, "user2")
+        assert row1.access_token == "access-c1"
+        assert row2.access_token == "access-c2"


### PR DESCRIPTION
## Summary
- inject `get_current_user_id` dependency into Google integration routes
- add OAuth flow tests covering multiple users
- document auth requirement and add missing google auth dependency

## Testing
- `ruff check .` *(fails: invalid `# noqa` directive and other errors)*
- `python3 -m pytest tests/test_google_oauth.py -q`
- `python3 -m pytest -q` *(fails: errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_689927249828832ab4ab8d81bdc8d502